### PR TITLE
Add EXPlib awareness

### DIFF
--- a/src/user/CMakeLists.txt
+++ b/src/user/CMakeLists.txt
@@ -19,7 +19,7 @@ set (common_INCLUDE_DIRS
   ${CMAKE_CURRENT_SOURCE_DIR}/..)
 
 set (common_LINKLIBS ${DEP_LIB} OpenMP::OpenMP_CXX MPI::MPI_CXX
-  exputil yaml-cpp)
+  exputil EXPlib yaml-cpp)
 
 if(CUDA_FOUND)
   list(APPEND common_INCLUDE_DIRS ${CUDA_TOOLKIT_INCLUDE})
@@ -100,4 +100,3 @@ if(ENABLE_USER_ALL)
   target_link_libraries(satwake PUBLIC expuser_common expuser_swake
     ${common_LINKLIBS})
 endif()
-


### PR DESCRIPTION
After a `make clean`, when compiling user modules, I was seeing undefined symbols:
```
[ 58%] Linking CXX shared library libuser.dylib
Undefined symbols for architecture arm64:
  "ExternalForce::determine_coefficients()", referenced from:
      vtable for UserTest in UserTest.cc.o
  "ExternalForce::determine_coefficients_thread(void*)", referenced from:
      vtable for UserTest in UserTest.cc.o
...
```
A look through `src/user/CMakeLists.txt` suggested that `ExternalForce` might be missing from the linked libraries. The addition of `EXPlib` seemed to fix for me -- maybe an old version was getting picked up in other compiles?