### PR TITLE
Manually remove my previous user modules entry

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,6 +8,3 @@
 [submodule "extern/HighFive"]
 	path = extern/HighFive
 	url = https://github.com/BlueBrain/HighFive.git
-[submodule "extern/user-modules/mycode1"]
-	path = extern/user-modules/mycode1
-	url = git@github.com:The9Cat/EXP-modules.git


### PR DESCRIPTION
Okay, I've realized that users using `git submodule add ...` for their personal module repos is *not* the way to go.  This causes git to change the `.gitmodule` file.   Not what we want.

Instead, we I think we want to `git clone` our personal repos into the `extern/user-modules` directory.