### PR TITLE
Allow Slurm support to be manually disabled 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ option(ENABLE_NBODY "Enable EXP n-body" ON)
 option(ENABLE_PYEXP "Enable the Python bindings" ON)
 option(ENABLE_PNG "Enable PNG graphics support" FALSE)
 option(ENABLE_CUDA "Enable CUDA" FALSE)
-option(ENABLE_SLURM "Enable SLURM" TRUE)
+option(ENABLE_SLURM "Enable SLURM checkpointing support" TRUE)
 option(ENABLE_XDR "Enable RPC/XDR support for Tipsy standard" FALSE)
 option(ENABLE_VTK "Configure VTK if available" FALSE)
 option(ENABLE_CUDA_SINGLE "Use real*4 instead of real*8 for CUDA" FALSE)
@@ -63,6 +63,7 @@ find_package(PNG)
 # Check for FE
 include(FEENABLE)
 
+# Check for Slurm if user has not set to false
 if(ENABLE_SLURM)
   find_package(SLURM)
 endif()


### PR DESCRIPTION
Slurm is automatically detected and enabled if the library and headers are available.  However, Unity now has an inconsistent Slurm install.  While I expect that this will get fixed, anticipating that there might be reasons for the user to disable Slurm support in other cases, I've added an `ENABLE_USER` flag .  In this case, one can disable the Slurm call using  `-DENABLE_SLURM=false` to `cmake`.  The default is: `ENABLE_SLURM: true`.

This changes the top-level `CMakeLists.txt` only.