### PR TITLE
External potential consistency

### DIFF
--- a/src/CBrockDisk.cc
+++ b/src/CBrockDisk.cc
@@ -504,10 +504,7 @@ void * CBrockDisk::determine_acceleration_and_potential_thread(void * arg)
       cC->AddAcc(j, 1, -potp*xx/fac);
     }
 
-    if (use_external)
-      cC->AddPotExt(j, potl);
-    else
-      cC->AddPot(j, potl);
+    cC->AddPot(j, potl);
 
     it++;
   }

--- a/src/Cube.cc
+++ b/src/Cube.cc
@@ -240,10 +240,8 @@ void * Cube::determine_acceleration_and_potential_thread(void * arg)
     cC->AddAcc(i, 0, accx.real());
     cC->AddAcc(i, 1, accy.real());
     cC->AddAcc(i, 2, accz.real());
-    if (use_external)
-      cC->AddPotExt(i, potl.real());
-    else
-      cC->AddPot(i, potl.real());
+
+    cC->AddPot(i, potl.real());
   }
   
   return (NULL);

--- a/src/Cylinder.cc
+++ b/src/Cylinder.cc
@@ -1279,10 +1279,7 @@ void * Cylinder::determine_acceleration_and_potential_thread(void * arg)
 #endif
       }
     
-      if (use_external)
-	cC->AddPotExt(indx, pa);
-      else
-	cC->AddPot(indx, pa);
+      cC->AddPot(indx, pa);
 
       if ( (component->EJ & Orient::AXIS) && !component->EJdryrun) 
 	frc[id] = component->orient->transformOrig() * frc[id];

--- a/src/Direct.cc
+++ b/src/Direct.cc
@@ -290,17 +290,14 @@ void * Direct::determine_acceleration_and_potential_thread(void * arg)
 	    cC->AddAcc(j, 1, fr*yy/(rr+1.0e-10) );
 	    cC->AddAcc(j, 2, fz );
 	  
-	    // External Potential
-	    //
-	    if (use_external) {
-	      cC->AddPotExt(j, pot );
 #ifdef DEBUG
+	    if (use_external) {
 	      ncnt++;
 	      tclausius[id] += mass * ( (fr*xx + fr*yy)/(rr+1.0e-10) + fz);
-#endif
 	    }
-	    // Internal potential
-	    else cC->AddPot(j, pot );
+#endif
+	    // Particle potential
+	    cC->AddPot(j, pot );
 
 	  }
 	  // END: Miyamoto-Nagai point mass
@@ -331,16 +328,15 @@ void * Direct::determine_acceleration_and_potential_thread(void * arg)
 	      cC->AddAcc(j, k, -mass *(cC->Pos(j, k) - pos[k]) * rfac );
 	    
 	    // Potential
-	    if (use_external) {
-	      cC->AddPotExt(j, pot );
 #ifdef DEBUG
+	    if (use_external) {
 	      ncnt++;
 	      for (int k=0; k<3; k++)
 		tclausius[id] += -mass *
 		  (cC->Pos(j, k) - pos[k]) * cC->Pos(j, k) * rfac;
-#endif
 	    }
-	    else cC->AddPot(j, pot );
+#endif
+	    cC->AddPot(j, pot );
 	  }
 	}
 	// END: spherical point mass

--- a/src/OutLog.cc
+++ b/src/OutLog.cc
@@ -489,7 +489,7 @@ void OutLog::Run(int n, int mstep, bool last)
       for (int k=0; k<3; k++) pos0[k] = c->Pos(i, k, Component::Centered);
 
       eptot1[indx]  += 0.5*p->mass*p->pot;
-      eptotx1[indx] += 0.5*p->mass*p->potext;
+      eptotx1[indx] += p->mass*p->potext;
       for (int k=0; k<3; k++) {
 	ektot1[indx]    += 0.5*p->mass*velL[k]*velL[k];
 	clausius1[indx] += p->mass*posL[k]*p->acc[k];

--- a/src/PolarBasis.cc
+++ b/src/PolarBasis.cc
@@ -1465,10 +1465,7 @@ void * PolarBasis::determine_acceleration_and_potential_thread(void * arg)
 	  cC->AddAcc(indx, 1,  potp*xx/rfac * frac);
 	}
 	
-	if (use_external)
-	  cC->AddPotExt(indx, potl * frac);
-	else
-	  cC->AddPot(indx, potl * frac);
+	cC->AddPot(indx, potl * frac);
       }
       // END: ratio < 1.0
 
@@ -1485,11 +1482,7 @@ void * PolarBasis::determine_acceleration_and_potential_thread(void * arg)
 	cC->AddAcc(indx, 1, yy*fr * cfrac);
 	cC->AddAcc(indx, 2, zz*fr * cfrac);
 
-	if (use_external)
-	  cC->AddPotExt(indx, pp * cfrac);
-	else
-	  cC->AddPot(indx, pp * cfrac);
-
+	cC->AddPot(indx, pp * cfrac);
       }
       // END: ratio > ratmin
     }

--- a/src/Shells.cc
+++ b/src/Shells.cc
@@ -164,10 +164,7 @@ void * Shells::determine_acceleration_and_potential_thread(void * arg)
 	cC->AddAcc(j, k, -cC->Pos(j, k) * rfac );
       
 				// Potential
-      if (use_external)
-	cC->AddPotExt(j, potl-mass/rr);
-      
-      else if (rr > 1.0e-16)
+      if (rr > 1.0e-16)
 	cC->AddPot(j, potl-mass/rr );
     }
   }

--- a/src/Slab.cc
+++ b/src/Slab.cc
@@ -317,10 +317,7 @@ void * Slab::determine_acceleration_and_potential_thread(void * arg)
     cC->AddAcc(i, 0, accx.real());
     cC->AddAcc(i, 1, accy.real());
     cC->AddAcc(i, 2, accz.real());
-    if (use_external)
-      cC->AddPotExt(i, potl.real());
-    else
-      cC->AddPot(i, potl.real());
+    cC->AddPot(i, potl.real());
   }
 
   return (NULL);

--- a/src/SlabSL.cc
+++ b/src/SlabSL.cc
@@ -295,10 +295,7 @@ void * SlabSL::determine_acceleration_and_potential_thread(void * arg)
     cC->AddAcc(i, 0, accx.real());
     cC->AddAcc(i, 1, accy.real());
     cC->AddAcc(i, 2, accz.real());
-    if (use_external)
-      cC->AddPotExt(i, potl.real());
-    else
-      cC->AddPot(i, potl.real());
+    cC->AddPot(i, potl.real());
   }
 
   return (NULL);

--- a/src/SphericalBasis.cc
+++ b/src/SphericalBasis.cc
@@ -1599,10 +1599,7 @@ void * SphericalBasis::determine_acceleration_and_potential_thread(void * arg)
 	cC->AddAcc(indx, 0,  potp*yy/fac );
 	cC->AddAcc(indx, 1, -potp*xx/fac );
       }
-      if (use_external)
-	cC->AddPotExt(indx, potl);
-      else
-	cC->AddPot(indx, potl);
+      cC->AddPot(indx, potl);
     }
 
   }


### PR DESCRIPTION
In OutLog, potentials from the forces are always multiplied by 0.5 when added to the total potential energy; external potentials were only multiplied by 0.5 when combining with potentials from the forces. However, this was not consistently done, such that the global and component-based external potential values were different by some factor. 

This is a draft fix where the external potential energy is multiplied by 0.5 when summed per particle. The fix creates more multiplications, which might not be preferable. It's also not obvious to me that we want the 0.5 factor in the first place?

I'm not 100% convinced I've fixed all the OutLog upgrades/consistencies yet, so I consider this a draft. 