### PR TITLE
Remove deprecated old time step criteria from the code

### DIFF
--- a/src/Component.cc
+++ b/src/Component.cc
@@ -586,7 +586,7 @@ void Component::print_level_lists(double T)
 	ofil << outdir << runtag << ".levels";
 	std::ofstream out(ofil.str().c_str(), ios::app);
 
-	unsigned curn, dtcnt, sum=0;
+	unsigned curn, dtcnt=6, sum=0;
 	out << setw(90) << std::setfill('-') << '-' << std::endl;
 	std::ostringstream sout;
 	sout << "--- Component <" << name 
@@ -596,22 +596,13 @@ void Component::print_level_lists(double T)
 	out << std::setw(3)  << "L" 
 	    << std::setw(10) << "Number" 
 	    << std::setw(10) << "dN/dL" 
-	    << std::setw(10) << "N(<=L)";
-	if (DTold) {
-	  out << std::setw(10) << "f(r/v)"
-	      << std::setw(10) << "f(s/v)"
-	      << std::setw(10) << "f(v/a)"
-	      << std::setw(10) << "f(r/a)";
-	  dtcnt = 5;
-	} else {
-	  out << std::setw(10) << "f(q/v)"
-	      << std::setw(10) << "f(v/a)"
-	      << std::setw(10) << "f(s/v)"
-	      << std::setw(10) << "f(r/v)" 
-	      << std::setw(10) << "f(r/a)";
-	  dtcnt = 6;
-	}
-	out << std::setw(10) << "f(int)" << std::endl;
+	    << std::setw(10) << "N(<=L)"
+	    << std::setw(10) << "f(q/v)"
+	    << std::setw(10) << "f(v/a)"
+	    << std::setw(10) << "f(s/v)"
+	    << std::setw(10) << "f(r/v)" 
+	    << std::setw(10) << "f(r/a)"
+	    << std::setw(10) << "f(int)" << std::endl;
 	out << std::setw(90) << std::setfill('-') << '-' << std::endl
 	    << std::setfill(' ');
 	for (unsigned n=0; n<=multistep; n++) {

--- a/src/ComponentContainer.cc
+++ b/src/ComponentContainer.cc
@@ -1141,36 +1141,22 @@ void ComponentContainer::print_level_list_header()
 	<< setw(15) << "int"     << ": internal time step (e.g. cooling)" 
 	<< endl;
     
-    if (DTold)
-      out << left << setw(15) << "r" 
-	  << ": coordinate radius" << endl
-	  << setw(15) << "f(r/v)"
-	  << ": fraction with dt=|r|/|v|" << endl
-	  << setw(15) << "f(s/v)" 
-	  << ": fraction with dt=s/|v|" << endl
-	  << setw(15) << "f(v/a)" 
-	  << ": fraction with dt=|v|/|a|" << endl
-	  << setw(15) << "f(r/a)" 
-	  << ": fraction with dt=sqrt(|r|/|a|)" << endl
-	  << setw(15) << "f(int)"
-	  << ": fraction with dt=dt(internal)" << endl;
-    else
-      out << left << setw(15) << "q" 
-	  << ": user-set resolution scale length" << endl
-	  << setw(15) << "f(q/v)"
-	  << ": fraction with dt=q/|v|" << endl
-	  << setw(15) << "f(v/a)" 
-	  << ": fraction with dt=|v|/|a|" << endl
-	  << setw(15) << "f(s/v)" 
-	  << ": fraction with dt=s/|v|" << endl
-	  << setw(15) << "r" 
-	  << ": grav. potential scale length, |phi|/|d(phi)/dx|"  << endl
-	  << setw(15) << "f(r/v)"
-	  << ": fraction with dt=|phi|/|d(phi)/dx * v|" << endl
-	  << setw(15) << "f(r/a)" 
-	  << ": fraction with dt=sqrt(|phi|/|a*a|)" << endl
-	  << setw(15) << "f(int)"
-	  << ": fraction with dt=dt(internal)" << endl;
+    out << left << setw(15) << "q" 
+	<< ": user-set resolution scale length" << endl
+	<< setw(15) << "f(q/v)"
+	<< ": fraction with dt=q/|v|" << endl
+	<< setw(15) << "f(v/a)" 
+	<< ": fraction with dt=|v|/|a|" << endl
+	<< setw(15) << "f(s/v)" 
+	<< ": fraction with dt=s/|v|" << endl
+	<< setw(15) << "r" 
+	<< ": grav. potential scale length, |phi|/|d(phi)/dx|"  << endl
+	<< setw(15) << "f(r/v)"
+	<< ": fraction with dt=|phi|/|d(phi)/dx * v|" << endl
+	<< setw(15) << "f(r/a)" 
+	<< ": fraction with dt=sqrt(|phi|/|a*a|)" << endl
+	<< setw(15) << "f(int)"
+	<< ": fraction with dt=dt(internal)" << endl;
     
     out << endl
 	<< "NB: simple particles, such as stars or dark matter, will have not" 

--- a/src/global.H
+++ b/src/global.H
@@ -99,8 +99,6 @@ extern int centerlevl;
 
 //! Fraction of dynamical time for determining multistep level
 //@{
-//! Use old (original) timestep criteria
-extern bool DTold;
 
 //! Scale coefficient (default: 1.00)
 extern double dynfracS;

--- a/src/global.cc
+++ b/src/global.cc
@@ -64,7 +64,6 @@ int             mstep      = 0;
 int             Mstep      = 1;
 int             centerlevl = -1;
 				// Timestep control
-bool            DTold      = false;
 double          dynfracS   = 1.00;
 double          dynfracD   = 1.0e32;
 double          dynfracV   = 0.01;

--- a/src/global_key_set.H
+++ b/src/global_key_set.H
@@ -23,7 +23,6 @@ global_valid_keys = {
   "dynfracV",
   "dynfracA",
   "dynfracP",
-  "DTold",
   "random_seed",
   "use_cwd",
   "eqmotion",

--- a/src/parse.cc
+++ b/src/parse.cc
@@ -111,12 +111,6 @@ void initialize(void)
     if (_G["dynfracA"])	     dynfracA   = _G["dynfracA"].as<double>();
     if (_G["dynfracP"])	     dynfracP   = _G["dynfracP"].as<double>();
 
-    if (_G["DTold"]) {
-      DTold = _G["DTold"].as<bool>();
-      if (DTold and myid==0)
-	cout << "---- Using original (old) time-step algorithm" << endl;
-    }
-    
     if (_G["random_seed"])     random_seed   = _G["random_seed"].as<unsigned int>();
     if (myid==0) {
       cout << "---- Random seed for Node 0 is: " << random_seed << std::endl;
@@ -362,7 +356,6 @@ void update_parm()
     
     if (not conf["multistep"])     conf["multistep"]   = multistep;
     if (not conf["centerlevl"])    conf["centerlevl"]  = centerlevl;
-    if (not conf["DTold"])         conf["DTold"]       = DTold;
     if (not conf["dynfracS"])      conf["dynfracS"]    = dynfracS;
     if (not conf["dynfracV"])      conf["dynfracV"]    = dynfracV;
     if (not conf["dynfracA"])      conf["dynfracA"]    = dynfracA;


### PR DESCRIPTION
The old time-step criteria have not been used for approx. 7 years, and I can't see any reason to recommend those moving forward.  We kept `DTold` for backward compatibility but the point of needed that is well past.

This PR removes the `DTold` option and the implementation of the old criteria.