### PR TITLE
Add missing changes for external potential to cuda code

### DIFF
--- a/src/cudaCylinder.cu
+++ b/src/cudaCylinder.cu
@@ -505,7 +505,7 @@ forceKernelCyl(dArray<cudaParticle> P, dArray<int> I,
 	       dArray<cudaTextureObject_t> tex,
 	       int stride, unsigned int mmax, unsigned int mlim,
 	       unsigned int nmax, PII lohi,
-	       cuFP_t rmax, cuFP_t cylmass, bool external)
+	       cuFP_t rmax, cuFP_t cylmass)
 {
   // Thread ID
   //
@@ -794,10 +794,7 @@ forceKernelCyl(dArray<cudaParticle> P, dArray<int> I,
 	for (int j=0; j<3; j++) p.acc[j] += acc[j];
       }
 
-      if (external)
-	p.potext += pa;
-      else
-	p.pot    += pa;
+      p.pot += pa;
 
     } // Particle index block
 
@@ -1822,7 +1819,7 @@ void Cylinder::determine_acceleration_cuda()
     forceKernelCyl<<<gridSize, BLOCK_SIZE, sMemSize, cs->stream>>>
       (toKernel(cs->cuda_particles), toKernel(cs->indx1),
        toKernel(dev_coefs), toKernel(t_d),
-       stride, mmax, mlim, nmax, lohi, rmax, cylmass, use_external);
+       stride, mmax, mlim, nmax, lohi, rmax, cylmass);
     
   }
 }

--- a/src/cudaPolarBasis.cu
+++ b/src/cudaPolarBasis.cu
@@ -545,8 +545,7 @@ forceKernelPlr6(dArray<cudaParticle> P, dArray<int> I,
 		dArray<cudaTextureObject_t> tex,
 		int stride, unsigned int mmax, unsigned int mlim,
 		unsigned int nmax, PII lohi,
-		cuFP_t rmax, cuFP_t plrmass,
-		bool external)
+		cuFP_t rmax, cuFP_t plrmass)
 {
   // Thread ID
   //
@@ -840,10 +839,7 @@ forceKernelPlr6(dArray<cudaParticle> P, dArray<int> I,
 	for (int j=0; j<3; j++) p.acc[j] += acc[j];
       }
 
-      if (external)
-	p.potext += pa;
-      else
-	p.pot    += pa;
+      p.pot += pa;
 
     } // Particle index block
 
@@ -1017,8 +1013,7 @@ forceKernelPlr3(dArray<cudaParticle> P, dArray<int> I,
 		dArray<cudaTextureObject_t> tex,
 		int stride, unsigned int mmax, unsigned int mlim,
 		unsigned int nmax, PII lohi,
-		cuFP_t rmax, cuFP_t plrmass,
-		bool external)
+		cuFP_t rmax, cuFP_t plrmass)
 {
   // Thread ID
   //
@@ -1260,10 +1255,7 @@ forceKernelPlr3(dArray<cudaParticle> P, dArray<int> I,
 	for (int j=0; j<3; j++) p.acc[j] += acc[j];
       }
       
-      if (external)
-	p.potext += pa;
-      else
-	p.pot    += pa;
+      p.pot += pa;
       
     } // Particle index block
 
@@ -2298,14 +2290,12 @@ void PolarBasis::determine_acceleration_cuda()
       forceKernelPlr3<<<gridSize, BLOCK_SIZE, sMemSize, cs->stream>>>
 	(toKernel(cs->cuda_particles), toKernel(cs->indx1),
 	 toKernel(dev_coefs), toKernel(t_d),
-	 stride, Mmax, mlim, nmax, lohi, rmax, cylmass,
-	 use_external);
+	 stride, Mmax, mlim, nmax, lohi, rmax, cylmass);
     else
       forceKernelPlr6<<<gridSize, BLOCK_SIZE, sMemSize, cs->stream>>>
 	(toKernel(cs->cuda_particles), toKernel(cs->indx1),
 	 toKernel(dev_coefs), toKernel(t_d),
-	 stride, Mmax, mlim, nmax, lohi, rmax, cylmass,
-	 use_external);
+	 stride, Mmax, mlim, nmax, lohi, rmax, cylmass);
   }
 }
 

--- a/src/cudaSphericalBasis.cu
+++ b/src/cudaSphericalBasis.cu
@@ -450,8 +450,7 @@ __global__ void coefKernel
 __global__ void
 forceKernel(dArray<cudaParticle> P, dArray<int> I, dArray<cuFP_t> coef,
 	    dArray<cudaTextureObject_t> tex, dArray<cuFP_t> L1, dArray<cuFP_t> L2,
-	    int stride, unsigned Lmax, unsigned int nmax, PII lohi, cuFP_t rmax,
-	    bool external)
+	    int stride, unsigned Lmax, unsigned int nmax, PII lohi, cuFP_t rmax)
 {
   const int tid   = blockDim.x * blockIdx.x + threadIdx.x;
   const int psiz  = (Lmax+1)*(Lmax+2)/2;
@@ -733,10 +732,7 @@ forceKernel(dArray<cudaParticle> P, dArray<int> I, dArray<cuFP_t> coef,
 	p.acc[0] +=  potp*yy/RR;
 	p.acc[1] += -potp*xx/RR;
       }
-      if (external)
-	p.potext += potl;
-      else
-	p.pot    += potl;
+      p.pot += potl;
 
 #ifdef NAN_CHECK
       // Sanity check
@@ -1363,7 +1359,7 @@ void SphericalBasis::determine_acceleration_cuda()
       (toKernel(cr->cuda_particles), toKernel(cr->indx1),
        toKernel(dev_coefs), toKernel(t_d),
        toKernel(cuS.plm1_d), toKernel(cuS.plm2_d),
-       stride, Lmax, nmax, lohi, rmax, use_external);
+       stride, Lmax, nmax, lohi, rmax);
   }
 }
 


### PR DESCRIPTION
I forgot to make the changes on the cuda sid in PR #30 .  This commit accomplishes that.

Compares correctly to the outlog data for CPU run of the `DiskHaloA` example.