### PR TITLE
(WIP) A couple of fixes for un-verified options.

### DIFF
--- a/src/CBrockDisk.cc
+++ b/src/CBrockDisk.cc
@@ -92,7 +92,7 @@ CBrockDisk::CBrockDisk(Component* c0, const YAML::Node& conf, MixtureBasis* m) :
 
   for (int l=0; l<=Lmax; l++) {
     for (int n=0; n<nmax; n++) {
-      sqnorm(l, n) = sqrt(norm(l, n));
+      sqnorm(l, n) = sqrt(norm(n, l));
     }
   }
 


### PR DESCRIPTION
This is a work-in-progress check of all options for CBrockDisk. 

Some functionality was not usable previously, and I appear to have inadvertently introduced a memory problem in a previous commit. 

This commit fixes these known bugs; more are likely present. Therefore, I propose a small to-do list (not strictly needed before merge, but maybe helpful):

- [ ] Develop a test suite and commit to `EXP-examples` (maybe in a subdirectory for specialised tests?)
- [x] Test `NO_M0`, `NO_M1`, `EVEN_M`, `M0_ONLY` options to verify expected potentials are returned.

