### PR TITLE
Implementation of std::advance with endpoint checking

### DIFF
--- a/coefs/expMSSA.cc
+++ b/coefs/expMSSA.cc
@@ -415,7 +415,7 @@ namespace MSSA {
 	size_t map_size  = mean.size();
 
 	auto u = mean.begin();
-	std::advance(u, thread_num);
+	for (int i=0; i<thread_num and u!=mean.end(); i++) u++;
 
 	for (int q=thread_num; q<map_size; q+=thread_count) {
 


### PR DESCRIPTION
The OpenMP parallel loop is implemented with a strided iterator.  This change manually ensures that the initial iterator position is not advanced beyond `end()`.