### PR TITLE
Restrict MPI requires to C and CXX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ set(CMAKE_FIND_PACKAGE_SORT_DIRECTION DEC)
 
 # Package support
 
-find_package(MPI REQUIRED)
+find_package(MPI REQUIRED COMPONENTS C CXX)
 find_package(Boost COMPONENTS serialization)
 find_package(OpenMP)
 find_package(FFTW)


### PR DESCRIPTION
There is some issue with the Homebrew openmpi 5 package such that the cmake can't find the library file for MPI_fortran , even though it does exist. EXP doesn't use the MPI Fortran compilers, so @The9Cat suggested the change in this PR. This fixed the build on Mac for me, and since it isn't really needed elsewhere, it seems worth it to just merge this up to EXP?