### PR TITLE
Add an MPI exclusion to BiorthCyl

### DIFF
--- a/exputil/EmpCyl2d.cc
+++ b/exputil/EmpCyl2d.cc
@@ -357,8 +357,7 @@ private:
 		  << std::string(60, '-') << std::endl
 		  << conf                 << std::endl
 		  << std::string(60, '-') << std::endl;
-      MPI_Finalize();
-      exit(-1);
+      throw std::runtime_error("EmpCyl2d::ExponCyl: error parsing YAML config");
     }
   }
 
@@ -416,8 +415,7 @@ private:
 		  << std::string(60, '-') << std::endl
 		  << conf                 << std::endl
 		  << std::string(60, '-') << std::endl;
-      MPI_Finalize();
-      exit(-1);
+      throw std::runtime_error("EmpCyl2d::KuzminCyl: error parsing YAML config");
     }
   }
 
@@ -475,8 +473,7 @@ protected:
 		  << std::string(60, '-') << std::endl
 		  << conf                 << std::endl
 		  << std::string(60, '-') << std::endl;
-      MPI_Finalize();
-      exit(-1);
+      throw std::runtime_error("EmpCyl2d::MestelCyl: error parsing YAML config");
     }
   }
 
@@ -586,8 +583,7 @@ protected:
 		  << std::string(60, '-') << std::endl
 		  << conf                 << std::endl
 		  << std::string(60, '-') << std::endl;
-      MPI_Finalize();
-      exit(-1);
+      throw std::runtime_error("EmpCyl2d::ZangCyl: error parsing YAML config");
     }
   }
 
@@ -690,8 +686,7 @@ std::shared_ptr<EmpCyl2d::ModelCyl> EmpCyl2d::createModel()
 		<< std::string(60, '-') << std::endl
 		<< Params               << std::endl
 		<< std::string(60, '-') << std::endl;
-    MPI_Finalize();
-    exit(-1);
+    throw std::runtime_error("EmpCyl2d::createModel: error parsing YAML config");
   }
 }
 

--- a/include/BiorthCyl.H
+++ b/include/BiorthCyl.H
@@ -48,7 +48,7 @@ protected:
   int mmax, nmax, numr, nmaxfid, mmin, mlim, nmin, nlim, knots, NQDHT;
   double rcylmin, rcylmax, scale, acyltbl, acylcut, Ninner, Mouter;
 
-  bool EVEN_M, verbose, logr;
+  bool EVEN_M, verbose, logr, use_mpi;
   
   //@{
   //! Grid parameters


### PR DESCRIPTION
This allows 2d basis construction cache construction to work with single process pyEXP runs.  Tested successfully with an `expon` disk construction. It's a fairly simple fix.  I'll exercise it a bit more and merge.