### PR TITLE
Velocity field bug fixes

### DIFF
--- a/expui/BiorthBess.cc
+++ b/expui/BiorthBess.cc
@@ -3,7 +3,7 @@
 #include <EXPException.H>
 #include <interp.H>
 #include <gaussQ.H>
-
+#include <cassert>
 
 BiorthBess::BiorthBess(double rmax, int lmax, int nmax, int RNUM) :
   rmax(rmax), lmax(lmax), nmax(nmax), RNUM(RNUM)

--- a/expui/Coefficients.cc
+++ b/expui/Coefficients.cc
@@ -2452,7 +2452,7 @@ namespace CoefClasses
       arr = it->second->store;
       int ldim = (Lmax+1)*(Lmax+2)/2;
       mat = std::make_shared<SphFldStruct::coefType>
-	(arr.data(), 4, ldim, Nmax); 
+	(arr.data(), Nfld, ldim, Nmax); 
     }
     
     return *mat;
@@ -2891,7 +2891,7 @@ namespace CoefClasses
     } else {
       arr = it->second->store;
       int mdim = Mmax + 1;
-      mat = std::make_shared<CylFldStruct::coefType>(arr.data(), 3, mdim, Nmax); 
+      mat = std::make_shared<CylFldStruct::coefType>(arr.data(), Nfld, mdim, Nmax); 
     }
     
     return *mat;
@@ -2918,7 +2918,7 @@ namespace CoefClasses
 
     if (it == coefs.end()) {
       std::ostringstream str;
-      str << "CylNfldCoefs::setMatrix: requested time=" << time << " not found";
+      str << "CylFldCoefs::setMatrix: requested time=" << time << " not found";
       throw std::runtime_error(str.str());
     } else {
       it->second->allocate();

--- a/pyEXP/CoefWrappers.cc
+++ b/pyEXP/CoefWrappers.cc
@@ -1321,7 +1321,12 @@ void CoefficientClasses(py::module &m) {
          SphFldCoefs instance
          )")
     .def("__call__",
-	 &CoefClasses::SphFldCoefs::getMatrix,
+	 [](CoefClasses::SphFldCoefs& A, double t)
+	 {
+	   Eigen::Tensor<std::complex<double>, 3> M = A.getMatrix(t);
+	   py::array_t<std::complex<double>> ret = make_ndarray<std::complex<double>>(M);
+	   return ret;
+	 },
          R"(
          Return the coefficient tensor for the desired time.
 
@@ -1342,7 +1347,12 @@ void CoefficientClasses(py::module &m) {
          )",
          py::arg("time"))
     .def("setMatrix",
-	 &CoefClasses::SphFldCoefs::setMatrix,
+	 [](CoefClasses::SphFldCoefs& A, double t,
+	    py::array_t<std::complex<double>> array)
+	 {
+	   auto M = make_tensor3<std::complex<double>>(array);
+	   A.setMatrix(t, M);
+	 },
          R"(
          Enter and/or rewrite the coefficient tensor at the provided time
 
@@ -1350,8 +1360,8 @@ void CoefficientClasses(py::module &m) {
          ----------
          time : float
              snapshot time corresponding to the the coefficient matrix
-             mat : numpy.ndarray
-                 the new coefficient array.
+         mat : numpy.ndarray
+             the new coefficient array.
 
          Returns
          -------
@@ -1396,7 +1406,12 @@ void CoefficientClasses(py::module &m) {
          CylFldCoefs instance
          )")
     .def("__call__",
-	 &CoefClasses::CylFldCoefs::getMatrix,
+	 [](CoefClasses::CylFldCoefs& A, double t)
+	 {
+	   Eigen::Tensor<std::complex<double>, 3> M = A.getMatrix(t);
+	   py::array_t<std::complex<double>> ret = make_ndarray<std::complex<double>>(M);
+	   return ret;
+	 },
          R"(
          Return the coefficient tensor for the desired time.
 
@@ -1417,7 +1432,12 @@ void CoefficientClasses(py::module &m) {
          )",
          py::arg("time"))
     .def("setMatrix",
-	 &CoefClasses::CylFldCoefs::setMatrix,
+	 [](CoefClasses::CylFldCoefs& A, double t,
+	    py::array_t<std::complex<double>> array)
+	 {
+	   auto M = make_tensor3<std::complex<double>>(array);
+	   A.setMatrix(t, M);
+	 },
          R"(
          Enter and/or rewrite the coefficient tensor at the provided time
 
@@ -1425,8 +1445,8 @@ void CoefficientClasses(py::module &m) {
          ----------
          time : float
              snapshot time corresponding to the the coefficient matrix
-             mat : numpy.ndarray
-                 the new coefficient array.
+         mat : numpy.ndarray
+             the new coefficient array.
 
          Returns
          -------

--- a/pyEXP/TensorToArray.H
+++ b/pyEXP/TensorToArray.H
@@ -27,6 +27,38 @@ py::array_t<T> make_ndarray(Eigen::Tensor<T, 3>& mat)
      );
 }
 
+template <typename T>
+Eigen::Tensor<T, 3> make_tensor3(py::array_t<T> array)
+{
+  // Request a buffer descriptor from Python
+  py::buffer_info buffer_info = array.request();
+
+  // Get the array dimenions
+  T *data = static_cast<T *>(buffer_info.ptr);
+  std::vector<ssize_t> shape = buffer_info.shape;
+
+  // Check rank
+  if (shape.size() != 3) {
+    std::ostringstream sout;
+    sout << "make_tensor3: tensor rank must be 3, found "
+	 << shape.size();
+    throw std::runtime_error(sout.str());
+  }
+
+  // Build result tensor with col-major ordering
+  Eigen::Tensor<T, 3> tensor(shape[0], shape[1], shape[2]);
+  for (int i=0, l=0; i < shape[0]; i++) {
+    for (int j=0; j < shape[1]; j++) {
+      for (int k=0; k < shape[2]; k++) {
+	tensor(i, j, k) = data[l++];
+      }
+    }
+  }
+
+  return tensor;
+}
+
+
 //! Helper function that maps the Eigen::Tensor<T, 4> into an numpy.ndarray
 template <typename T>
 py::array_t<T> make_ndarray4(Eigen::Tensor<T, 4>& mat)
@@ -52,5 +84,39 @@ py::array_t<T> make_ndarray4(Eigen::Tensor<T, 4>& mat)
      mat.data()
      );
 }
+
+template <typename T>
+Eigen::Tensor<T, 4> make_tensor4(py::array_t<T> array)
+{
+  // Request a buffer descriptor from Python
+  py::buffer_info buffer_info = array.request();
+
+  // Get the array dimenions
+  T *data = static_cast<T *>(buffer_info.ptr);
+  std::vector<ssize_t> shape = buffer_info.shape;
+
+  // Check rank
+  if (shape.size() != 4) {
+    std::ostringstream sout;
+    sout << "make_tensor4: tensor rank must be 4, found "
+	 << shape.size();
+    throw std::runtime_error(sout.str());
+  }
+
+  // Build result tensor with col-major ordering
+  Eigen::Tensor<T, 4> tensor(shape[0], shape[1], shape[2], shape[3]);
+  for (int i=0, l=0; i < shape[0]; i++) {
+    for (int j=0; j < shape[1]; j++) {
+      for (int k=0; k < shape[2]; k++) {
+	for (int l=0; l < shape[3]; k++) {
+	  tensor(i, j, k, l) = data[l++];
+	}
+      }
+    }
+  }
+
+  return tensor;
+}
+
 
 #endif

--- a/src/OutVel.cc
+++ b/src/OutVel.cc
@@ -39,7 +39,7 @@ OutVel::OutVel(const YAML::Node& conf) : Output(conf)
 
   // Target output file
   //
-  outfile = "velcoef." +  tcomp->name + "." + runtag;
+  outfile = outdir + "velcoef." +  tcomp->name + "." + runtag;
 
   // Check for valid model type
   //


### PR DESCRIPTION
**A number of minor bug fixes**
- Correct the number of fields to the `SphFldStruct`  and `CylFldStruct` constructors.  Should be: `Nfld`, a configurable parameter.
- Add interface code to allow pyEXP to set a coefficient matrix for `SphFldStruct` and `CylFldStruct`.
I have tested this in pyEXP but it needs more exercise.