### PR TITLE
Implementation of a point set evaluator for FieldGenerator

### DIFF
--- a/expui/FieldGenerator.H
+++ b/expui/FieldGenerator.H
@@ -20,6 +20,7 @@ namespace Field
     
     std::vector<double> times, pmin, pmax;
     std::vector<int>    grid;
+    Eigen::MatrixXd     mesh;
     
     //! Sanity check time vector with coefficient DB
     void check_times(CoefClasses::CoefsPtr coefs);
@@ -35,11 +36,31 @@ namespace Field
 
   public:
     
-    //! Constructor
+    //! Constructor for a rectangular grid
     FieldGenerator(const std::vector<double> &time,
 		   const std::vector<double> &pmin,
 		   const std::vector<double> &pmax,
 		   const std::vector<int>    &grid);
+
+    //! Constructor for an arbitrary point mesh.  The mesh should be
+    //! an Nx3 array
+    FieldGenerator(const std::vector<double> &time,
+		   const Eigen::MatrixXd     &mesh);
+
+    /** Get field quantities at user defined points
+
+	For example:
+	.
+	.
+	// Generate the fields for all coefficients in 'coefs'
+	auto db = points(basis, coefs);
+
+	// Get fields evaluated at Time=3.14 and for all points in
+	// your supplied mesh for density ("dens")
+	Eigen::MatrixXf points = db["3.14"]["dens"];
+    */
+    std::map<double, std::map<std::string, Eigen::VectorXf>>
+    points(BasisClasses::BasisPtr basis, CoefClasses::CoefsPtr coefs);
 
     /** Get a field slices as a map in time and type
 

--- a/pyEXP/FieldWrappers.cc
+++ b/pyEXP/FieldWrappers.cc
@@ -24,22 +24,24 @@ void FieldGeneratorClasses(py::module &m) {
     a list of upper bounds, and a list of knots per dimension.  These
     lists all have rank 3 for (x, y, z).  For a two-dimensional surface,
     one of the knot array values must be zero.  The member functions
-    lines, slices and volumes, called with the basis and coefficient
-    objects, return a numpy.ndarray containing the field evaluations.
-    Each of these functions returns a dictionary of times to a dictionary
-    of field names to numpy.ndarrays at each time.  There are also members
-    which will write these generated fields to files. The linear probe
-    members, 'lines' and 'file_lines', evaluate 'num' field points along
-    a user-specified segment between the 3d points 'beg' and 'end'.  See
-    help(pyEXP.basis) and help(pyEXP.coefs) for info on the basis and
-    coefficient objects.
+    lines, slices, an arbitrary point-set, and volumes, called with the
+    basis and coefficient objects, return a numpy.ndarray containing the
+    field evaluations.  Each of these functions returns a dictionary of
+    times to a dictionary of field names to numpy.ndarrays at each time.
+    There are also members which will write these generated fields to files.
+    The linear probe members, 'lines' and 'file_lines', evaluate 'num'
+    field points along a user-specified segment between the 3d points 'beg'
+    and 'end'.  See help(pyEXP.basis) and help(pyEXP.coefs) for info on
+    the basis and coefficient objects.
 
     Data packing
     ------------
     All slices and volumes are returned as numpy.ndarrays in row-major
     order.  That is, the first index is x, the second is y, and the
     third is z.  The ranks are specified by the 'gridsize' array with
-    (nx, ny, nz) as input to the FieldGenerator constructor.
+    (nx, ny, nz) as input to the FieldGenerator constructor.  A point
+    mesh is rows of (x, y, z) Cartesian coordinates.  The output field
+    values returned by points is in the same order as the input array.
 
     Coordinate systems
     ------------------
@@ -116,6 +118,24 @@ void FieldGeneratorClasses(py::module &m) {
 	py::arg("times"), py::arg("lower"), py::arg("upper"),
 	py::arg("gridsize"));
 
+  f.def(py::init<const std::vector<double>, const Eigen::MatrixXd>(),
+	R"(
+        Create fields for given times and and provided point set
+
+        Parameters
+        ----------
+        times : list(float,...)
+            list of evaluation times
+        mesh : ndarray of Nx3 floats
+            point set (x, y, z) for field evaluation
+
+        Returns
+        -------
+        FieldGenerator
+            new object
+        )",
+	py::arg("times"), py::arg("mesh"));
+
   f.def("setMidplane", &Field::FieldGenerator::setMidplane,
 	R"(
         Set the field generator to generate midplane fields
@@ -160,6 +180,38 @@ void FieldGeneratorClasses(py::module &m) {
 
         See also
         --------
+        points : generate fields at an array of mesh points
+        lines : generate fields along a line given by its end points
+        volumes : generate fields in volume given by the initializtion grid
+       )", py::arg("basis"), py::arg("coefs"));
+  
+  f.def("points", &Field::FieldGenerator::points,
+	R"(
+        Return a dictionary of arrays (1d numpy arrays) indexed by time
+        and field type corresponding to the mesh points
+
+        Parameters
+        ----------
+        basis : Basis
+            basis instance of any geometry; geometry will be deduced by the generator
+        coefs : Coefs
+            coefficient container instance
+
+        Returns
+        -------
+        dict({time: {field-name: numpy.ndarray})
+            dictionary of times, field names, and data arrays
+
+        Notes
+        -----
+        Each data array in the dictionary is a 1-dimensional array with the
+        same order as the mesh points in the constructor
+        routines.
+
+        See also
+        --------
+        slices : generate fields in a surface slice given by the
+                 initializtion grid
         lines : generate fields along a line given by its end points
         volumes : generate fields in volume given by the initializtion grid
        )", py::arg("basis"), py::arg("coefs"));
@@ -196,7 +248,9 @@ void FieldGeneratorClasses(py::module &m) {
 
         See also
         --------
-        slices : generate fields in a surface slice given by the initializtion grid
+        points : generate fields at an array of mesh points
+        slices : generate fields in a surface slice given by the
+                 initializtion grid
         volumes : generate fields in volume given by the initializtion grid
         )",
 	py::arg("basis"), py::arg("coefs"),
@@ -281,7 +335,9 @@ void FieldGeneratorClasses(py::module &m) {
 
         See also
         --------
-        slices : generate fields in a surface slice given by the initializtion grid
+        points : generate fields at an array of mesh points
+        slices : generate fields in a surface slice given by the
+                 initializtion grid
         volumes : generate fields in volume given by the initializtion grid
         lines : generate fields along a line given by its end points
         )", 
@@ -314,7 +370,9 @@ void FieldGeneratorClasses(py::module &m) {
 
         See also
         --------
-        slices : generate fields in a surface slice given by the initializtion grid
+        points : generate fields at an array of mesh points
+        slices : generate fields in a surface slice given by the
+                 initializtion grid
         volumes : generate fields in volume given by the initializtion grid
         lines : generate fields along a line given by its end points
         )",
@@ -357,6 +415,8 @@ void FieldGeneratorClasses(py::module &m) {
 
         See also
         --------
+        points : generate fields at an array of mesh points
+
         lines : generate fields along a line given by its end points
         slices : generate fields in a slice given by the initializtion grid
         )");


### PR DESCRIPTION
**New feature**

- `FieldGenerator` now takes an arbitrary list of evaluation points and returns fields evaluated at those points using the `points` member.
- The input points are an N x 3 numpy.ndarray.  I.e. rows are (x, y, z) values.  This is signaled with a second constructor which takes the time and input point array as input values
- The `points` evaluation routine provides dictionary output just like `surfaces` or `volumes`.  The only difference is that the each field is now a one-dimensional array in the same order as the input points.
- The evaluation is both multithreaded and MPI aware
- I did some preliminary testing tested and the `surfaces` grid member output and confirmed that the results are the same.

This PR contains _only_ this one new feature.