### PR TITLE
Proposed fix to improve pybind11 dynamic type casting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: CTest Quick
         working-directory: ./build
-        run: ctest -L quick
+        run: ctest --output-on-failure -L quick
         
       #- name: CTest Long
       #working-directory: ./build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,8 +34,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential libeigen3-dev libfftw3-dev libhdf5-dev libopenmpi-dev libomp-dev
-          sudo pip install numpy
+          sudo apt-get install -y build-essential libeigen3-dev libfftw3-dev libhdf5-dev libopenmpi-dev libomp-dev python3-numpy
 
 
       - name: Setup submodule and build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,13 +13,11 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, ubuntu-22.04]
-        c_compiler: [gcc, clang]
-        cpp_compiler: [g++, clang++]
         include:
-          - c_compiler: gcc
-            cpp_compiler: g++
-          - c_compiler: clang
-            cpp_compiler: clang++
+          - cc: gcc
+            cxx: g++
+          - cc: clang
+            cxx: clang++
 
     name: "Test pyEXP Build"
     runs-on: ${{ matrix.os }}
@@ -44,6 +42,7 @@ jobs:
         if: runner.os == 'Linux'
         env:
           CC: ${{ matrix.cc }}
+          CXX: ${{ matrix.cxx }}
         working-directory: ./build
         run: >-
           cmake

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,14 +12,14 @@ jobs:
   exp:
     strategy:
       matrix:
-        os: [ubuntu-latest]
-        cc: [gcc]
+        os: [ubuntu-latest, ubuntu-22.04]
+        cc: [gcc, mpicc]
 
     name: "Test pyEXP Build"
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install core dependencies - ubuntu
         if: runner.os == 'Linux'
@@ -27,6 +27,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y build-essential libeigen3-dev libfftw3-dev libhdf5-dev libopenmpi-dev
           sudo pip install numpy
+
 
       - name: Setup submodule and build
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential libeigen3-dev libfftw3-dev libhdf5-dev libopenmpi-dev cmake gdb python3-dev libpython3-dev
+          sudo apt-get install -y build-essential libeigen3-dev libfftw3-dev libhdf5-dev libopenmpi-dev
           sudo pip install numpy
 
 
@@ -43,7 +43,7 @@ jobs:
           cmake
           -DENABLE_NBODY=YES
           -DENABLE_PYEXP=YES
-          -DCMAKE_BUILD_TYPE=Debug
+          -DCMAKE_BUILD_TYPE=Release
           -DEigen3_DIR=/usr/include/eigen3/share/eigen3/cmake
           -DCMAKE_INSTALL_PREFIX=./install
           -Wno-dev
@@ -59,4 +59,4 @@ jobs:
         
       #- name: CTest Long
       #working-directory: ./build
-      #run: ctest -L long
+      #run: ctest --output-on-failure -L long

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,11 +13,16 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, ubuntu-22.04]
+        cc: [gcc, clang]
+        cxx: [g++, clang++]
         include:
+          - cxx: clang++
+            cxxflags: -stdlib=libstdc++
+        exclude:
           - cc: gcc
-            cxx: g++
-          - cc: clang
             cxx: clang++
+          - cc: clang
+            cxx: g++
 
     name: "Test pyEXP Build"
     runs-on: ${{ matrix.os }}
@@ -51,6 +56,7 @@ jobs:
           -DCMAKE_BUILD_TYPE=Release
           -DEigen3_DIR=/usr/include/eigen3/share/eigen3/cmake
           -DCMAKE_INSTALL_PREFIX=./install
+          -DCMAKE_CXX_FLAGS=${{ matrix.cxxflags }}
           -Wno-dev
           ..
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
   exp:
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-22.04]
+        os: [ubuntu-24.04, ubuntu-22.04]
         cc: [gcc, clang]
         cxx: [g++, clang++]
         include:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential libeigen3-dev libfftw3-dev libhdf5-dev libopenmpi-dev
+          sudo apt-get install -y build-essential libeigen3-dev libfftw3-dev libhdf5-dev libopenmpi-dev cmake gdb python3-dev libpython3-dev
           sudo pip install numpy
 
 
@@ -43,7 +43,7 @@ jobs:
           cmake
           -DENABLE_NBODY=YES
           -DENABLE_PYEXP=YES
-          -DCMAKE_BUILD_TYPE=Release
+          -DCMAKE_BUILD_TYPE=Debug
           -DEigen3_DIR=/usr/include/eigen3/share/eigen3/cmake
           -DCMAKE_INSTALL_PREFIX=./install
           -Wno-dev

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential libeigen3-dev libfftw3-dev libhdf5-dev libopenmpi-dev
+          sudo apt-get install -y build-essential libeigen3-dev libfftw3-dev libhdf5-dev libopenmpi-dev libomp-dev
           sudo pip install numpy
 
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,13 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, ubuntu-22.04]
-        cc: [gcc, mpicc]
+        c_compiler: [gcc, clang]
+        cpp_compiler: [g++, clang++]
+        include:
+          - c_compiler: gcc
+            cpp_compiler: g++
+          - c_compiler: clang
+            cpp_compiler: clang++
 
     name: "Test pyEXP Build"
     runs-on: ${{ matrix.os }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,6 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 # Compiler flags.  Not all tested thoroughly...
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   # using Clang
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
   # using GCC
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "Intel")

--- a/expui/BasisFactory.H
+++ b/expui/BasisFactory.H
@@ -205,13 +205,13 @@ namespace BasisClasses
 
     //! Accumulate coefficient contributions from arrays
     virtual void
-    addFromArray(Eigen::VectorXd m, RowMatrixXd p, bool roundrobin,
+    addFromArray(Eigen::VectorXd& m, RowMatrixXd& p, bool roundrobin,
 		 bool posvelrows) = 0;
 
     //! Generate coeffients from an array and optional center location
     //! for the expansion
     CoefClasses::CoefStrPtr createFromArray
-    (Eigen::VectorXd m, RowMatrixXd p, double time=0.0,
+    (Eigen::VectorXd& m, RowMatrixXd& p, double time=0.0,
      std::vector<double> center={0.0, 0.0, 0.0},
      bool roundrobin=true, bool posvelrows=false);
 

--- a/expui/BasisFactory.H
+++ b/expui/BasisFactory.H
@@ -205,13 +205,13 @@ namespace BasisClasses
 
     //! Accumulate coefficient contributions from arrays
     virtual void
-    addFromArray(Eigen::VectorXd& m, RowMatrixXd& p, bool roundrobin,
+    addFromArray(Eigen::VectorXd m, RowMatrixXd p, bool roundrobin,
 		 bool posvelrows) = 0;
 
     //! Generate coeffients from an array and optional center location
     //! for the expansion
     CoefClasses::CoefStrPtr createFromArray
-    (Eigen::VectorXd& m, RowMatrixXd& p, double time=0.0,
+    (Eigen::VectorXd m, RowMatrixXd p, double time=0.0,
      std::vector<double> center={0.0, 0.0, 0.0},
      bool roundrobin=true, bool posvelrows=false);
 

--- a/expui/BasisFactory.cc
+++ b/expui/BasisFactory.cc
@@ -272,7 +272,7 @@ namespace BasisClasses
   // Generate coefficients from a phase-space table
   //
   CoefClasses::CoefStrPtr Basis::createFromArray
-  (Eigen::VectorXd m, RowMatrixXd p, double time, std::vector<double> ctr,
+  (Eigen::VectorXd& m, RowMatrixXd& p, double time, std::vector<double> ctr,
    bool roundrobin, bool posvelrows)
   {
     initFromArray(ctr);

--- a/expui/BasisFactory.cc
+++ b/expui/BasisFactory.cc
@@ -272,7 +272,7 @@ namespace BasisClasses
   // Generate coefficients from a phase-space table
   //
   CoefClasses::CoefStrPtr Basis::createFromArray
-  (Eigen::VectorXd& m, RowMatrixXd& p, double time, std::vector<double> ctr,
+  (Eigen::VectorXd m, RowMatrixXd p, double time, std::vector<double> ctr,
    bool roundrobin, bool posvelrows)
   {
     initFromArray(ctr);

--- a/expui/BiorthBasis.H
+++ b/expui/BiorthBasis.H
@@ -97,7 +97,7 @@ namespace BasisClasses
     //! Generate coeffients from an array and optional center location
     //! for the expansion
     CoefClasses::CoefStrPtr createFromArray
-    (Eigen::VectorXd& m, RowMatrixXd& p, double time=0.0,
+    (Eigen::VectorXd m, RowMatrixXd p, double time=0.0,
      std::vector<double> center={0.0, 0.0, 0.0},
      bool roundrobin=true, bool posvelrows=false);
     
@@ -113,7 +113,7 @@ namespace BasisClasses
     //! Initialize accumulating coefficients from arrays.  This is
     //! called once to initialize the accumulation.
     void addFromArray
-    (Eigen::VectorXd& m, RowMatrixXd& p,
+    (Eigen::VectorXd m, RowMatrixXd p,
      bool roundrobin=true, bool posvelrows=false);
     
     //! Create and the coefficients from the array accumulation with the

--- a/expui/BiorthBasis.H
+++ b/expui/BiorthBasis.H
@@ -97,7 +97,7 @@ namespace BasisClasses
     //! Generate coeffients from an array and optional center location
     //! for the expansion
     CoefClasses::CoefStrPtr createFromArray
-    (Eigen::VectorXd m, RowMatrixXd p, double time=0.0,
+    (Eigen::VectorXd& m, RowMatrixXd& p, double time=0.0,
      std::vector<double> center={0.0, 0.0, 0.0},
      bool roundrobin=true, bool posvelrows=false);
     
@@ -113,7 +113,7 @@ namespace BasisClasses
     //! Initialize accumulating coefficients from arrays.  This is
     //! called once to initialize the accumulation.
     void addFromArray
-    (Eigen::VectorXd m, RowMatrixXd p,
+    (Eigen::VectorXd& m, RowMatrixXd& p,
      bool roundrobin=true, bool posvelrows=false);
     
     //! Create and the coefficients from the array accumulation with the

--- a/expui/BiorthBasis.cc
+++ b/expui/BiorthBasis.cc
@@ -368,7 +368,7 @@ namespace BasisClasses
   {
     // Sanity check on derived class type
     //
-    if (typeid(*coef) != typeid(CoefClasses::SphStruct))
+    if (typeid(coef.get()) != typeid(CoefClasses::SphStruct*))
       throw std::runtime_error("Spherical::set_coefs: you must pass a CoefClasses::SphStruct");
 
     // Sanity check on dimensionality
@@ -1431,7 +1431,7 @@ namespace BasisClasses
 
   void Cylindrical::set_coefs(CoefClasses::CoefStrPtr coef)
   {
-    if (typeid(*coef) != typeid(CoefClasses::CylStruct))
+    if (typeid(coef.get()) != typeid(CoefClasses::CylStruct*))
       throw std::runtime_error("Cylindrical::set_coefs: you must pass a CoefClasses::CylStruct");
 
     CoefClasses::CylStruct* cf = dynamic_cast<CoefClasses::CylStruct*>(coef.get());
@@ -1708,7 +1708,7 @@ namespace BasisClasses
   {
     // Sanity check on derived class type
     //
-    if (typeid(*coef) != typeid(CoefClasses::CylStruct))
+    if (typeid(coef.get()) != typeid(CoefClasses::CylStruct*))
       throw std::runtime_error("FlatDisk::set_coefs: you must pass a CoefClasses::CylStruct");
 
     // Sanity check on dimensionality
@@ -2140,7 +2140,7 @@ namespace BasisClasses
   {
     // Sanity check on derived class type
     //
-    if (typeid(*coef) != typeid(CoefClasses::SlabStruct))
+    if (typeid(coef) != typeid(CoefClasses::SlabStruct*))
       throw std::runtime_error("Slab::set_coefs: you must pass a CoefClasses::SlabStruct");
 
     // Sanity check on dimensionality
@@ -2572,7 +2572,7 @@ namespace BasisClasses
   {
     // Sanity check on derived class type
     //
-    if (typeid(*coef) != typeid(CoefClasses::CubeStruct))
+    if (typeid(coef.get()) != typeid(CoefClasses::CubeStruct*))
       throw std::runtime_error("Cube::set_coefs: you must pass a CoefClasses::CubeStruct");
 
     // Sanity check on dimensionality

--- a/expui/BiorthBasis.cc
+++ b/expui/BiorthBasis.cc
@@ -2847,7 +2847,7 @@ namespace BasisClasses
   }
 
   // Accumulate coefficient contributions from arrays
-  void BiorthBasis::addFromArray(Eigen::VectorXd m, RowMatrixXd p,
+  void BiorthBasis::addFromArray(Eigen::VectorXd& m, RowMatrixXd& p,
 				 bool RoundRobin, bool PosVelRows)
   {
     // Sanity check: is coefficient instance created?  This is not
@@ -2957,7 +2957,7 @@ namespace BasisClasses
   // Generate coefficients from a phase-space table
   //
   CoefClasses::CoefStrPtr BiorthBasis::createFromArray
-  (Eigen::VectorXd m, RowMatrixXd p, double time, std::vector<double> ctr,
+  (Eigen::VectorXd& m, RowMatrixXd& p, double time, std::vector<double> ctr,
    bool RoundRobin, bool PosVelRows)
   {
     initFromArray(ctr);

--- a/expui/BiorthBasis.cc
+++ b/expui/BiorthBasis.cc
@@ -2847,7 +2847,7 @@ namespace BasisClasses
   }
 
   // Accumulate coefficient contributions from arrays
-  void BiorthBasis::addFromArray(Eigen::VectorXd& m, RowMatrixXd& p,
+  void BiorthBasis::addFromArray(Eigen::VectorXd m, RowMatrixXd p,
 				 bool RoundRobin, bool PosVelRows)
   {
     // Sanity check: is coefficient instance created?  This is not
@@ -2957,7 +2957,7 @@ namespace BasisClasses
   // Generate coefficients from a phase-space table
   //
   CoefClasses::CoefStrPtr BiorthBasis::createFromArray
-  (Eigen::VectorXd& m, RowMatrixXd& p, double time, std::vector<double> ctr,
+  (Eigen::VectorXd m, RowMatrixXd p, double time, std::vector<double> ctr,
    bool RoundRobin, bool PosVelRows)
   {
     initFromArray(ctr);

--- a/expui/CoefContainer.cc
+++ b/expui/CoefContainer.cc
@@ -72,7 +72,7 @@ namespace MSSA
       unpack_cylfld();
     }
     else {
-      throw std::runtime_error(std::string("CoefDB::unpack_channels(): can not reflect coefficient type=") + typeid(*coefs.get()).name());
+      throw std::runtime_error(std::string("CoefDB::unpack_channels(): can not reflect coefficient type=") + typeid(coefs.get()).name());
     }
 
     return coefs;
@@ -91,7 +91,7 @@ namespace MSSA
     else if (dynamic_cast<CoefClasses::CylFldCoefs*>(coefs.get()))
       { } // Do nothing
     else {
-      throw std::runtime_error(std::string("CoefDB::background(): can not reflect coefficient type=") + typeid(*coefs.get()).name());
+      throw std::runtime_error(std::string("CoefDB::background(): can not reflect coefficient type=") + typeid(coefs.get()).name());
     }
   }
 
@@ -112,7 +112,7 @@ namespace MSSA
     else if (dynamic_cast<CoefClasses::CylFldCoefs*>(coefs.get()))
       pack_cylfld();
     else {
-      throw std::runtime_error(std::string("CoefDB::pack_channels(): can not reflect coefficient type=") + typeid(*coefs.get()).name());
+      throw std::runtime_error(std::string("CoefDB::pack_channels(): can not reflect coefficient type=") + typeid(coefs.get()).name());
     }
   }
 

--- a/expui/Coefficients.H
+++ b/expui/Coefficients.H
@@ -111,7 +111,7 @@ namespace CoefClasses
     virtual Eigen::VectorXcd& getData(double time) = 0;
 
     //! Set coefficient store at given time to the provided matrix
-    virtual void setData(double time, const Eigen::VectorXcd& data) = 0;
+    virtual void setData(double time, Eigen::Ref<Eigen::VectorXcd> data) = 0;
 
     //! Interpolate coefficient matrix at given time
     std::tuple<Eigen::VectorXcd&, bool> interpolate(double time);
@@ -273,10 +273,10 @@ namespace CoefClasses
     Eigen::MatrixXcd& getMatrix(double time);
 
     //! Set coefficient matrix at given time
-    virtual void setData(double time, const Eigen::VectorXcd& arr);
+    virtual void setData(double time, Eigen::Ref<Eigen::VectorXcd> arr);
 
     //! Natural data setter for pyEXP
-    void setMatrix(double time, const Eigen::MatrixXcd& mat);
+    void setMatrix(double time, Eigen::Ref<Eigen::MatrixXcd> mat);
 
     //! Interpolate coefficient matrix at given time
     std::tuple<Eigen::MatrixXcd&, bool> interpolate(double time)
@@ -411,10 +411,10 @@ namespace CoefClasses
     Eigen::MatrixXcd& getMatrix(double time);
     
     //! Set coefficient matrix at given time
-    virtual void setData(double time, const Eigen::VectorXcd& arr);
+    virtual void setData(double time, Eigen::Ref<Eigen::VectorXcd> arr);
     
     //! For pyEXP
-    void setMatrix(double time, const Eigen::MatrixXcd& arr);
+    void setMatrix(double time, Eigen::Ref<Eigen::MatrixXcd> arr);
     
     //! Interpolate coefficient matrix at given time
     std::tuple<Eigen::MatrixXcd&, bool> interpolate(double time)
@@ -542,7 +542,7 @@ namespace CoefClasses
     virtual Eigen3d& getTensor(double time);
     
     //! Set coefficient matrix at given time
-    virtual void setData(double time, const Eigen::VectorXcd& dat);
+    virtual void setData(double time, Eigen::Ref<Eigen::VectorXcd> dat);
 
     //! Native version
     virtual void setTensor(double time, const Eigen3d& dat);
@@ -673,7 +673,7 @@ namespace CoefClasses
     virtual Eigen3d& getTensor(double time);
     
     //! Set coefficient matrix at given time
-    virtual void setData(double time, const Eigen::VectorXcd& dat);
+    virtual void setData(double time, Eigen::Ref<Eigen::VectorXcd> dat);
 
     //! Native version
     virtual void setTensor(double time, const Eigen3d& dat);
@@ -810,9 +810,7 @@ namespace CoefClasses
     /** Set coefficient matrix at given time.  This is for pybind11,
 	since the operator() will not allow lvalue assignment, it
 	seems. */
-    virtual void setData(double time, const Eigen::VectorXcd& arr);
-
-    void setArray(double time, const Eigen::VectorXcd& arr) { setData(time, arr); }
+    virtual void setData(double time, Eigen::Ref<Eigen::VectorXcd> arr);
 
     //! Get coefficient structure at a given time
     virtual std::shared_ptr<CoefStruct> getCoefStruct(double time)
@@ -914,7 +912,7 @@ namespace CoefClasses
     SphFldStruct::coefType& getMatrix(double time);
 
     //! Set coefficient matrix at given time
-    virtual void setData(double time, const Eigen::VectorXcd& arr);
+    virtual void setData(double time, Eigen::Ref<Eigen::VectorXcd> arr);
 
     //! Natural data setter for pyEXP
     void setMatrix(double time, const SphFldStruct::coefType& mat);
@@ -1041,7 +1039,7 @@ namespace CoefClasses
     CylFldStruct::coefType & getMatrix(double time);
 
     //! Set coefficient matrix at given time
-    virtual void setData(double time, const Eigen::VectorXcd& arr);
+    virtual void setData(double time, Eigen::Ref<Eigen::VectorXcd> arr);
 
     //! Natural data setter for pyEXP
     void setMatrix(double time, const CylFldStruct::coefType& mat);

--- a/expui/Coefficients.H
+++ b/expui/Coefficients.H
@@ -111,7 +111,7 @@ namespace CoefClasses
     virtual Eigen::VectorXcd& getData(double time) = 0;
 
     //! Set coefficient store at given time to the provided matrix
-    virtual void setData(double time, Eigen::VectorXcd data) = 0;
+    virtual void setData(double time, Eigen::VectorXcd& data) = 0;
 
     //! Interpolate coefficient matrix at given time
     std::tuple<Eigen::VectorXcd&, bool> interpolate(double time);
@@ -273,10 +273,10 @@ namespace CoefClasses
     Eigen::MatrixXcd& getMatrix(double time);
 
     //! Set coefficient matrix at given time
-    virtual void setData(double time, Eigen::VectorXcd arr);
+    virtual void setData(double time, Eigen::VectorXcd& arr);
 
     //! Natural data setter for pyEXP
-    void setMatrix(double time, Eigen::MatrixXcd mat);
+    void setMatrix(double time, Eigen::MatrixXcd& mat);
 
     //! Interpolate coefficient matrix at given time
     std::tuple<Eigen::MatrixXcd&, bool> interpolate(double time)
@@ -411,10 +411,10 @@ namespace CoefClasses
     Eigen::MatrixXcd& getMatrix(double time);
     
     //! Set coefficient matrix at given time
-    virtual void setData(double time, Eigen::VectorXcd arr);
+    virtual void setData(double time, Eigen::VectorXcd& arr);
     
     //! For pyEXP
-    void setMatrix(double time, Eigen::MatrixXcd arr);
+    void setMatrix(double time, Eigen::MatrixXcd& arr);
     
     //! Interpolate coefficient matrix at given time
     std::tuple<Eigen::MatrixXcd&, bool> interpolate(double time)
@@ -542,10 +542,10 @@ namespace CoefClasses
     virtual Eigen3d& getTensor(double time);
     
     //! Set coefficient matrix at given time
-    virtual void setData(double time, Eigen::VectorXcd dat);
+    virtual void setData(double time, Eigen::VectorXcd& dat);
 
     //! Native version
-    virtual void setTensor(double time, const Eigen3d dat);
+    virtual void setTensor(double time, const Eigen3d& dat);
     
     //! Interpolate coefficient tensor at given time
     std::tuple<Eigen::Tensor<std::complex<double>, 3>&, bool>
@@ -673,10 +673,10 @@ namespace CoefClasses
     virtual Eigen3d& getTensor(double time);
     
     //! Set coefficient matrix at given time
-    virtual void setData(double time, Eigen::VectorXcd dat);
+    virtual void setData(double time, Eigen::VectorXcd& dat);
 
     //! Native version
-    virtual void setTensor(double time, const Eigen3d dat);
+    virtual void setTensor(double time, const Eigen3d& dat);
     
     //! Interpolate coefficient tensor at given time
     std::tuple<Eigen::Tensor<std::complex<double>, 3>&, bool>
@@ -810,9 +810,9 @@ namespace CoefClasses
     /** Set coefficient matrix at given time.  This is for pybind11,
 	since the operator() will not allow lvalue assignment, it
 	seems. */
-    virtual void setData(double time, Eigen::VectorXcd arr);
+    virtual void setData(double time, Eigen::VectorXcd& arr);
 
-    void setArray(double time, Eigen::VectorXcd arr)
+    void setArray(double time, Eigen::VectorXcd& arr)
     { setData(time, arr); }
 
     //! Get coefficient structure at a given time
@@ -915,10 +915,10 @@ namespace CoefClasses
     SphFldStruct::dataType getMatrix(double time);
 
     //! Set coefficient matrix at given time
-    virtual void setData(double time, Eigen::VectorXcd arr);
+    virtual void setData(double time, Eigen::VectorXcd& arr);
 
     //! Natural data setter for pyEXP
-    void setMatrix(double time, SphFldStruct::dataType mat);
+    void setMatrix(double time, SphFldStruct::dataType& mat);
 
     //! Interpolate coefficient matrix at given time
     std::tuple<SphFldStruct::coefType&, bool> interpolate(double time)
@@ -1042,10 +1042,10 @@ namespace CoefClasses
     CylFldStruct::dataType getMatrix(double time);
 
     //! Set coefficient matrix at given time
-    virtual void setData(double time, Eigen::VectorXcd arr);
+    virtual void setData(double time, Eigen::VectorXcd& arr);
 
     //! Natural data setter for pyEXP
-    void setMatrix(double time, CylFldStruct::dataType mat);
+    void setMatrix(double time, CylFldStruct::dataType& mat);
 
     //! Interpolate coefficient matrix at given time
     std::tuple<CylFldStruct::coefType&, bool> interpolate(double time)

--- a/expui/Coefficients.H
+++ b/expui/Coefficients.H
@@ -111,7 +111,7 @@ namespace CoefClasses
     virtual Eigen::VectorXcd& getData(double time) = 0;
 
     //! Set coefficient store at given time to the provided matrix
-    virtual void setData(double time, Eigen::Ref<Eigen::VectorXcd> data) = 0;
+    virtual void setData(double time, Eigen::VectorXcd& data) = 0;
 
     //! Interpolate coefficient matrix at given time
     std::tuple<Eigen::VectorXcd&, bool> interpolate(double time);
@@ -273,10 +273,10 @@ namespace CoefClasses
     Eigen::MatrixXcd& getMatrix(double time);
 
     //! Set coefficient matrix at given time
-    virtual void setData(double time, Eigen::Ref<Eigen::VectorXcd> arr);
+    virtual void setData(double time, Eigen::VectorXcd& arr);
 
     //! Natural data setter for pyEXP
-    void setMatrix(double time, Eigen::Ref<Eigen::MatrixXcd> mat);
+    void setMatrix(double time, Eigen::MatrixXcd& mat);
 
     //! Interpolate coefficient matrix at given time
     std::tuple<Eigen::MatrixXcd&, bool> interpolate(double time)
@@ -411,10 +411,10 @@ namespace CoefClasses
     Eigen::MatrixXcd& getMatrix(double time);
     
     //! Set coefficient matrix at given time
-    virtual void setData(double time, Eigen::Ref<Eigen::VectorXcd> arr);
+    virtual void setData(double time, Eigen::VectorXcd& arr);
     
     //! For pyEXP
-    void setMatrix(double time, Eigen::Ref<Eigen::MatrixXcd> arr);
+    void setMatrix(double time, Eigen::MatrixXcd& arr);
     
     //! Interpolate coefficient matrix at given time
     std::tuple<Eigen::MatrixXcd&, bool> interpolate(double time)
@@ -542,7 +542,7 @@ namespace CoefClasses
     virtual Eigen3d& getTensor(double time);
     
     //! Set coefficient matrix at given time
-    virtual void setData(double time, Eigen::Ref<Eigen::VectorXcd> dat);
+    virtual void setData(double time, Eigen::VectorXcd& dat);
 
     //! Native version
     virtual void setTensor(double time, const Eigen3d& dat);
@@ -673,7 +673,7 @@ namespace CoefClasses
     virtual Eigen3d& getTensor(double time);
     
     //! Set coefficient matrix at given time
-    virtual void setData(double time, Eigen::Ref<Eigen::VectorXcd> dat);
+    virtual void setData(double time, Eigen::VectorXcd& dat);
 
     //! Native version
     virtual void setTensor(double time, const Eigen3d& dat);
@@ -810,7 +810,10 @@ namespace CoefClasses
     /** Set coefficient matrix at given time.  This is for pybind11,
 	since the operator() will not allow lvalue assignment, it
 	seems. */
-    virtual void setData(double time, Eigen::Ref<Eigen::VectorXcd> arr);
+    virtual void setData(double time, Eigen::VectorXcd& arr);
+
+    void setArray(double time, Eigen::VectorXcd& arr)
+    { setData(time, arr); }
 
     //! Get coefficient structure at a given time
     virtual std::shared_ptr<CoefStruct> getCoefStruct(double time)
@@ -909,13 +912,13 @@ namespace CoefClasses
     virtual Eigen::VectorXcd& getData(double time);
     
     //! Operator for pyEXP
-    SphFldStruct::coefType& getMatrix(double time);
+    SphFldStruct::dataType getMatrix(double time);
 
     //! Set coefficient matrix at given time
-    virtual void setData(double time, Eigen::Ref<Eigen::VectorXcd> arr);
+    virtual void setData(double time, Eigen::VectorXcd& arr);
 
     //! Natural data setter for pyEXP
-    void setMatrix(double time, const SphFldStruct::coefType& mat);
+    void setMatrix(double time, SphFldStruct::dataType& mat);
 
     //! Interpolate coefficient matrix at given time
     std::tuple<SphFldStruct::coefType&, bool> interpolate(double time)
@@ -1036,13 +1039,13 @@ namespace CoefClasses
     virtual Eigen::VectorXcd& getData(double time);
     
     //! Operator for pyEXP
-    CylFldStruct::coefType & getMatrix(double time);
+    CylFldStruct::dataType getMatrix(double time);
 
     //! Set coefficient matrix at given time
-    virtual void setData(double time, Eigen::Ref<Eigen::VectorXcd> arr);
+    virtual void setData(double time, Eigen::VectorXcd& arr);
 
     //! Natural data setter for pyEXP
-    void setMatrix(double time, const CylFldStruct::coefType& mat);
+    void setMatrix(double time, CylFldStruct::dataType& mat);
 
     //! Interpolate coefficient matrix at given time
     std::tuple<CylFldStruct::coefType&, bool> interpolate(double time)

--- a/expui/Coefficients.H
+++ b/expui/Coefficients.H
@@ -111,7 +111,7 @@ namespace CoefClasses
     virtual Eigen::VectorXcd& getData(double time) = 0;
 
     //! Set coefficient store at given time to the provided matrix
-    virtual void setData(double time, Eigen::VectorXcd& data) = 0;
+    virtual void setData(double time, Eigen::VectorXcd data) = 0;
 
     //! Interpolate coefficient matrix at given time
     std::tuple<Eigen::VectorXcd&, bool> interpolate(double time);
@@ -273,10 +273,10 @@ namespace CoefClasses
     Eigen::MatrixXcd& getMatrix(double time);
 
     //! Set coefficient matrix at given time
-    virtual void setData(double time, Eigen::VectorXcd& arr);
+    virtual void setData(double time, Eigen::VectorXcd arr);
 
     //! Natural data setter for pyEXP
-    void setMatrix(double time, Eigen::MatrixXcd& mat);
+    void setMatrix(double time, Eigen::MatrixXcd mat);
 
     //! Interpolate coefficient matrix at given time
     std::tuple<Eigen::MatrixXcd&, bool> interpolate(double time)
@@ -411,10 +411,10 @@ namespace CoefClasses
     Eigen::MatrixXcd& getMatrix(double time);
     
     //! Set coefficient matrix at given time
-    virtual void setData(double time, Eigen::VectorXcd& arr);
+    virtual void setData(double time, Eigen::VectorXcd arr);
     
     //! For pyEXP
-    void setMatrix(double time, Eigen::MatrixXcd& arr);
+    void setMatrix(double time, Eigen::MatrixXcd arr);
     
     //! Interpolate coefficient matrix at given time
     std::tuple<Eigen::MatrixXcd&, bool> interpolate(double time)
@@ -542,10 +542,10 @@ namespace CoefClasses
     virtual Eigen3d& getTensor(double time);
     
     //! Set coefficient matrix at given time
-    virtual void setData(double time, Eigen::VectorXcd& dat);
+    virtual void setData(double time, Eigen::VectorXcd dat);
 
     //! Native version
-    virtual void setTensor(double time, const Eigen3d& dat);
+    virtual void setTensor(double time, const Eigen3d dat);
     
     //! Interpolate coefficient tensor at given time
     std::tuple<Eigen::Tensor<std::complex<double>, 3>&, bool>
@@ -673,10 +673,10 @@ namespace CoefClasses
     virtual Eigen3d& getTensor(double time);
     
     //! Set coefficient matrix at given time
-    virtual void setData(double time, Eigen::VectorXcd& dat);
+    virtual void setData(double time, Eigen::VectorXcd dat);
 
     //! Native version
-    virtual void setTensor(double time, const Eigen3d& dat);
+    virtual void setTensor(double time, const Eigen3d dat);
     
     //! Interpolate coefficient tensor at given time
     std::tuple<Eigen::Tensor<std::complex<double>, 3>&, bool>
@@ -810,9 +810,9 @@ namespace CoefClasses
     /** Set coefficient matrix at given time.  This is for pybind11,
 	since the operator() will not allow lvalue assignment, it
 	seems. */
-    virtual void setData(double time, Eigen::VectorXcd& arr);
+    virtual void setData(double time, Eigen::VectorXcd arr);
 
-    void setArray(double time, Eigen::VectorXcd& arr)
+    void setArray(double time, Eigen::VectorXcd arr)
     { setData(time, arr); }
 
     //! Get coefficient structure at a given time
@@ -915,10 +915,10 @@ namespace CoefClasses
     SphFldStruct::dataType getMatrix(double time);
 
     //! Set coefficient matrix at given time
-    virtual void setData(double time, Eigen::VectorXcd& arr);
+    virtual void setData(double time, Eigen::VectorXcd arr);
 
     //! Natural data setter for pyEXP
-    void setMatrix(double time, SphFldStruct::dataType& mat);
+    void setMatrix(double time, SphFldStruct::dataType mat);
 
     //! Interpolate coefficient matrix at given time
     std::tuple<SphFldStruct::coefType&, bool> interpolate(double time)
@@ -1042,10 +1042,10 @@ namespace CoefClasses
     CylFldStruct::dataType getMatrix(double time);
 
     //! Set coefficient matrix at given time
-    virtual void setData(double time, Eigen::VectorXcd& arr);
+    virtual void setData(double time, Eigen::VectorXcd arr);
 
     //! Natural data setter for pyEXP
-    void setMatrix(double time, CylFldStruct::dataType& mat);
+    void setMatrix(double time, CylFldStruct::dataType mat);
 
     //! Interpolate coefficient matrix at given time
     std::tuple<CylFldStruct::coefType&, bool> interpolate(double time)

--- a/expui/Coefficients.cc
+++ b/expui/Coefficients.cc
@@ -469,13 +469,13 @@ namespace CoefClasses
     return mat;
   }
   
-  void SphCoefs::setData(double time, Eigen::Ref<Eigen::VectorXcd> dat)
+  void SphCoefs::setData(double time, Eigen::VectorXcd& dat)
   {
     auto it = coefs.find(roundTime(time));
 
     if (it == coefs.end()) {
       std::ostringstream str;
-      str << "SphCoefs::setMatrix: requested time=" << time << " not found";
+      str << "SphCoefs::setData: requested time=" << time << " not found";
       throw std::runtime_error(str.str());
     } else {
       it->second->store = dat;
@@ -484,7 +484,7 @@ namespace CoefClasses
     }
   }
   
-  void SphCoefs::setMatrix(double time, Eigen::Ref<Eigen::MatrixXcd> dat)
+  void SphCoefs::setMatrix(double time, Eigen::MatrixXcd& dat)
   {
     auto it = coefs.find(roundTime(time));
 
@@ -891,13 +891,13 @@ namespace CoefClasses
     return mat;
   }
   
-  void CylCoefs::setData(double time, Eigen::Ref<Eigen::VectorXcd> dat)
+  void CylCoefs::setData(double time, Eigen::VectorXcd& dat)
   {
     auto it = coefs.find(roundTime(time));
 
     if (it == coefs.end()) {
       std::ostringstream str;
-      str << "CylCoefs::setMatrix: requested time=" << time << " not found";
+      str << "CylCoefs::setData: requested time=" << time << " not found";
       throw std::runtime_error(str.str());
     } else {
       it->second->store = dat;
@@ -906,7 +906,7 @@ namespace CoefClasses
     }
   }
 
-  void CylCoefs::setMatrix(double time, Eigen::Ref<Eigen::MatrixXcd> dat)
+  void CylCoefs::setMatrix(double time, Eigen::MatrixXcd& dat)
   {
     auto it = coefs.find(roundTime(time));
 
@@ -1247,13 +1247,13 @@ namespace CoefClasses
     return arr;
   }
 
-  void SlabCoefs::setData(double time, Eigen::Ref<Eigen::VectorXcd> dat)
+  void SlabCoefs::setData(double time, Eigen::VectorXcd& dat)
   {
     auto it = coefs.find(roundTime(time));
 
     if (it == coefs.end()) {
       std::ostringstream str;
-      str << "CylCoefs::setMatrix: requested time=" << time << " not found";
+      str << "CylCoefs::setData: requested time=" << time << " not found";
       throw std::runtime_error(str.str());
     } else {
       it->second->store = dat;
@@ -1268,7 +1268,7 @@ namespace CoefClasses
 
     if (it == coefs.end()) {
       std::ostringstream str;
-      str << "CylCoefs::setMatrix: requested time=" << time << " not found";
+      str << "SlabCoefs::setTensor: requested time=" << time << " not found";
       throw std::runtime_error(str.str());
     } else {
       it->second->allocate();	// Assign storage for the flattened tensor
@@ -1599,13 +1599,13 @@ namespace CoefClasses
     return arr;
   }
 
-  void CubeCoefs::setData(double time, Eigen::Ref<Eigen::VectorXcd> dat)
+  void CubeCoefs::setData(double time, Eigen::VectorXcd& dat)
   {
     auto it = coefs.find(roundTime(time));
 
     if (it == coefs.end()) {
       std::ostringstream str;
-      str << "CylCoefs::setMatrix: requested time=" << time << " not found";
+      str << "CubeCoefs::setData: requested time=" << time << " not found";
       throw std::runtime_error(str.str());
     } else {
       it->second->store = dat;
@@ -1620,7 +1620,7 @@ namespace CoefClasses
 
     if (it == coefs.end()) {
       std::ostringstream str;
-      str << "CylCoefs::setMatrix: requested time=" << time << " not found";
+      str << "CubeCoefs::setTensor: requested time=" << time << " not found";
       throw std::runtime_error(str.str());
     } else {
       it->second->allocate();	// Assign storage for the flattened tensor
@@ -1968,13 +1968,13 @@ namespace CoefClasses
     return arr;
   }
   
-  void TableData::setData(double time, Eigen::Ref<Eigen::VectorXcd> dat)
+  void TableData::setData(double time, Eigen::VectorXcd& dat)
   {
     auto it = coefs.find(roundTime(time));
 
     if (it == coefs.end()) {
       std::ostringstream str;
-      str << "TableData::setMatrix: requested time=" << time << " not found";
+      str << "TableData::setData: requested time=" << time << " not found";
       throw std::runtime_error(str.str());
     } else {
       it->second->store = dat;
@@ -2442,7 +2442,7 @@ namespace CoefClasses
     return arr;
   }
   
-  SphFldStruct::coefType & SphFldCoefs::getMatrix(double time)
+  SphFldStruct::dataType SphFldCoefs::getMatrix(double time)
   {
     auto it = coefs.find(roundTime(time));
 
@@ -2458,13 +2458,13 @@ namespace CoefClasses
     return *mat;
   }
   
-  void SphFldCoefs::setData(double time, Eigen::Ref<Eigen::VectorXcd> dat)
+  void SphFldCoefs::setData(double time, Eigen::VectorXcd& dat)
   {
     auto it = coefs.find(roundTime(time));
 
     if (it == coefs.end()) {
       std::ostringstream str;
-      str << "SphVelCoefs::setMatrix: requested time=" << time << " not found";
+      str << "SphFldCoefs::setData: requested time=" << time << " not found";
       throw std::runtime_error(str.str());
     } else {
       it->second->store = dat;
@@ -2473,13 +2473,13 @@ namespace CoefClasses
     }
   }
   
-  void SphFldCoefs::setMatrix(double time, const SphFldStruct::coefType& dat)
+  void SphFldCoefs::setMatrix(double time, SphFldStruct::dataType& dat)
   {
     auto it = coefs.find(roundTime(time));
 
     if (it == coefs.end()) {
       std::ostringstream str;
-      str << "SphVelCoefs::setMatrix: requested time=" << time << " not found";
+      str << "SphFldCoefs::setMatrix: requested time=" << time << " not found";
       throw std::runtime_error(str.str());
     } else {
       it->second->allocate();
@@ -2882,7 +2882,7 @@ namespace CoefClasses
     return arr;
   }
   
-  CylFldStruct::coefType & CylFldCoefs::getMatrix(double time)
+  CylFldStruct::dataType CylFldCoefs::getMatrix(double time)
   {
     auto it = coefs.find(roundTime(time));
 
@@ -2897,7 +2897,7 @@ namespace CoefClasses
     return *mat;
   }
   
-  void CylFldCoefs::setData(double time, Eigen::Ref<Eigen::VectorXcd> dat)
+  void CylFldCoefs::setData(double time, Eigen::VectorXcd& dat)
   {
     auto it = coefs.find(roundTime(time));
 
@@ -2912,7 +2912,7 @@ namespace CoefClasses
     }
   }
   
-  void CylFldCoefs::setMatrix(double time, const CylFldStruct::coefType& dat)
+  void CylFldCoefs::setMatrix(double time, CylFldStruct::dataType& dat)
   {
     auto it = coefs.find(roundTime(time));
 

--- a/expui/Coefficients.cc
+++ b/expui/Coefficients.cc
@@ -469,7 +469,7 @@ namespace CoefClasses
     return mat;
   }
   
-  void SphCoefs::setData(double time, Eigen::VectorXcd& dat)
+  void SphCoefs::setData(double time, Eigen::VectorXcd dat)
   {
     auto it = coefs.find(roundTime(time));
 
@@ -484,7 +484,7 @@ namespace CoefClasses
     }
   }
   
-  void SphCoefs::setMatrix(double time, Eigen::MatrixXcd& dat)
+  void SphCoefs::setMatrix(double time, Eigen::MatrixXcd dat)
   {
     auto it = coefs.find(roundTime(time));
 
@@ -891,7 +891,7 @@ namespace CoefClasses
     return mat;
   }
   
-  void CylCoefs::setData(double time, Eigen::VectorXcd& dat)
+  void CylCoefs::setData(double time, Eigen::VectorXcd dat)
   {
     auto it = coefs.find(roundTime(time));
 
@@ -906,7 +906,7 @@ namespace CoefClasses
     }
   }
 
-  void CylCoefs::setMatrix(double time, Eigen::MatrixXcd& dat)
+  void CylCoefs::setMatrix(double time, Eigen::MatrixXcd dat)
   {
     auto it = coefs.find(roundTime(time));
 
@@ -1247,7 +1247,7 @@ namespace CoefClasses
     return arr;
   }
 
-  void SlabCoefs::setData(double time, Eigen::VectorXcd& dat)
+  void SlabCoefs::setData(double time, Eigen::VectorXcd dat)
   {
     auto it = coefs.find(roundTime(time));
 
@@ -1262,7 +1262,7 @@ namespace CoefClasses
     }
   }
 
-  void SlabCoefs::setTensor(double time, const Eigen3d& dat)
+  void SlabCoefs::setTensor(double time, const Eigen3d dat)
   {
     auto it = coefs.find(roundTime(time));
 
@@ -1599,7 +1599,7 @@ namespace CoefClasses
     return arr;
   }
 
-  void CubeCoefs::setData(double time, Eigen::VectorXcd& dat)
+  void CubeCoefs::setData(double time, Eigen::VectorXcd dat)
   {
     auto it = coefs.find(roundTime(time));
 
@@ -1614,7 +1614,7 @@ namespace CoefClasses
     }
   }
 
-  void CubeCoefs::setTensor(double time, const Eigen3d& dat)
+  void CubeCoefs::setTensor(double time, const Eigen3d dat)
   {
     auto it = coefs.find(roundTime(time));
 
@@ -1968,7 +1968,7 @@ namespace CoefClasses
     return arr;
   }
   
-  void TableData::setData(double time, Eigen::VectorXcd& dat)
+  void TableData::setData(double time, Eigen::VectorXcd dat)
   {
     auto it = coefs.find(roundTime(time));
 
@@ -2458,7 +2458,7 @@ namespace CoefClasses
     return *mat;
   }
   
-  void SphFldCoefs::setData(double time, Eigen::VectorXcd& dat)
+  void SphFldCoefs::setData(double time, Eigen::VectorXcd dat)
   {
     auto it = coefs.find(roundTime(time));
 
@@ -2473,7 +2473,7 @@ namespace CoefClasses
     }
   }
   
-  void SphFldCoefs::setMatrix(double time, SphFldStruct::dataType& dat)
+  void SphFldCoefs::setMatrix(double time, SphFldStruct::dataType dat)
   {
     auto it = coefs.find(roundTime(time));
 
@@ -2897,7 +2897,7 @@ namespace CoefClasses
     return *mat;
   }
   
-  void CylFldCoefs::setData(double time, Eigen::VectorXcd& dat)
+  void CylFldCoefs::setData(double time, Eigen::VectorXcd dat)
   {
     auto it = coefs.find(roundTime(time));
 
@@ -2912,7 +2912,7 @@ namespace CoefClasses
     }
   }
   
-  void CylFldCoefs::setMatrix(double time, CylFldStruct::dataType& dat)
+  void CylFldCoefs::setMatrix(double time, CylFldStruct::dataType dat)
   {
     auto it = coefs.find(roundTime(time));
 

--- a/expui/Coefficients.cc
+++ b/expui/Coefficients.cc
@@ -469,7 +469,7 @@ namespace CoefClasses
     return mat;
   }
   
-  void SphCoefs::setData(double time, const Eigen::VectorXcd& dat)
+  void SphCoefs::setData(double time, Eigen::Ref<Eigen::VectorXcd> dat)
   {
     auto it = coefs.find(roundTime(time));
 
@@ -484,7 +484,7 @@ namespace CoefClasses
     }
   }
   
-  void SphCoefs::setMatrix(double time, const Eigen::MatrixXcd& dat)
+  void SphCoefs::setMatrix(double time, Eigen::Ref<Eigen::MatrixXcd> dat)
   {
     auto it = coefs.find(roundTime(time));
 
@@ -891,7 +891,7 @@ namespace CoefClasses
     return mat;
   }
   
-  void CylCoefs::setData(double time, const Eigen::VectorXcd& dat)
+  void CylCoefs::setData(double time, Eigen::Ref<Eigen::VectorXcd> dat)
   {
     auto it = coefs.find(roundTime(time));
 
@@ -906,7 +906,7 @@ namespace CoefClasses
     }
   }
 
-  void CylCoefs::setMatrix(double time, const Eigen::MatrixXcd& dat)
+  void CylCoefs::setMatrix(double time, Eigen::Ref<Eigen::MatrixXcd> dat)
   {
     auto it = coefs.find(roundTime(time));
 
@@ -1247,7 +1247,7 @@ namespace CoefClasses
     return arr;
   }
 
-  void SlabCoefs::setData(double time, const Eigen::VectorXcd& dat)
+  void SlabCoefs::setData(double time, Eigen::Ref<Eigen::VectorXcd> dat)
   {
     auto it = coefs.find(roundTime(time));
 
@@ -1599,7 +1599,7 @@ namespace CoefClasses
     return arr;
   }
 
-  void CubeCoefs::setData(double time, const Eigen::VectorXcd& dat)
+  void CubeCoefs::setData(double time, Eigen::Ref<Eigen::VectorXcd> dat)
   {
     auto it = coefs.find(roundTime(time));
 
@@ -1968,7 +1968,7 @@ namespace CoefClasses
     return arr;
   }
   
-  void TableData::setData(double time, const Eigen::VectorXcd& dat)
+  void TableData::setData(double time, Eigen::Ref<Eigen::VectorXcd> dat)
   {
     auto it = coefs.find(roundTime(time));
 
@@ -2458,7 +2458,7 @@ namespace CoefClasses
     return *mat;
   }
   
-  void SphFldCoefs::setData(double time, const Eigen::VectorXcd& dat)
+  void SphFldCoefs::setData(double time, Eigen::Ref<Eigen::VectorXcd> dat)
   {
     auto it = coefs.find(roundTime(time));
 
@@ -2897,7 +2897,7 @@ namespace CoefClasses
     return *mat;
   }
   
-  void CylFldCoefs::setData(double time, const Eigen::VectorXcd& dat)
+  void CylFldCoefs::setData(double time, Eigen::Ref<Eigen::VectorXcd> dat)
   {
     auto it = coefs.find(roundTime(time));
 

--- a/expui/Coefficients.cc
+++ b/expui/Coefficients.cc
@@ -469,7 +469,7 @@ namespace CoefClasses
     return mat;
   }
   
-  void SphCoefs::setData(double time, Eigen::VectorXcd dat)
+  void SphCoefs::setData(double time, Eigen::VectorXcd& dat)
   {
     auto it = coefs.find(roundTime(time));
 
@@ -484,7 +484,7 @@ namespace CoefClasses
     }
   }
   
-  void SphCoefs::setMatrix(double time, Eigen::MatrixXcd dat)
+  void SphCoefs::setMatrix(double time, Eigen::MatrixXcd& dat)
   {
     auto it = coefs.find(roundTime(time));
 
@@ -891,7 +891,7 @@ namespace CoefClasses
     return mat;
   }
   
-  void CylCoefs::setData(double time, Eigen::VectorXcd dat)
+  void CylCoefs::setData(double time, Eigen::VectorXcd& dat)
   {
     auto it = coefs.find(roundTime(time));
 
@@ -906,7 +906,7 @@ namespace CoefClasses
     }
   }
 
-  void CylCoefs::setMatrix(double time, Eigen::MatrixXcd dat)
+  void CylCoefs::setMatrix(double time, Eigen::MatrixXcd& dat)
   {
     auto it = coefs.find(roundTime(time));
 
@@ -1247,7 +1247,7 @@ namespace CoefClasses
     return arr;
   }
 
-  void SlabCoefs::setData(double time, Eigen::VectorXcd dat)
+  void SlabCoefs::setData(double time, Eigen::VectorXcd& dat)
   {
     auto it = coefs.find(roundTime(time));
 
@@ -1262,7 +1262,7 @@ namespace CoefClasses
     }
   }
 
-  void SlabCoefs::setTensor(double time, const Eigen3d dat)
+  void SlabCoefs::setTensor(double time, const Eigen3d& dat)
   {
     auto it = coefs.find(roundTime(time));
 
@@ -1599,7 +1599,7 @@ namespace CoefClasses
     return arr;
   }
 
-  void CubeCoefs::setData(double time, Eigen::VectorXcd dat)
+  void CubeCoefs::setData(double time, Eigen::VectorXcd& dat)
   {
     auto it = coefs.find(roundTime(time));
 
@@ -1614,7 +1614,7 @@ namespace CoefClasses
     }
   }
 
-  void CubeCoefs::setTensor(double time, const Eigen3d dat)
+  void CubeCoefs::setTensor(double time, const Eigen3d& dat)
   {
     auto it = coefs.find(roundTime(time));
 
@@ -1968,7 +1968,7 @@ namespace CoefClasses
     return arr;
   }
   
-  void TableData::setData(double time, Eigen::VectorXcd dat)
+  void TableData::setData(double time, Eigen::VectorXcd& dat)
   {
     auto it = coefs.find(roundTime(time));
 
@@ -2458,7 +2458,7 @@ namespace CoefClasses
     return *mat;
   }
   
-  void SphFldCoefs::setData(double time, Eigen::VectorXcd dat)
+  void SphFldCoefs::setData(double time, Eigen::VectorXcd& dat)
   {
     auto it = coefs.find(roundTime(time));
 
@@ -2473,7 +2473,7 @@ namespace CoefClasses
     }
   }
   
-  void SphFldCoefs::setMatrix(double time, SphFldStruct::dataType dat)
+  void SphFldCoefs::setMatrix(double time, SphFldStruct::dataType& dat)
   {
     auto it = coefs.find(roundTime(time));
 
@@ -2897,7 +2897,7 @@ namespace CoefClasses
     return *mat;
   }
   
-  void CylFldCoefs::setData(double time, Eigen::VectorXcd dat)
+  void CylFldCoefs::setData(double time, Eigen::VectorXcd& dat)
   {
     auto it = coefs.find(roundTime(time));
 
@@ -2912,7 +2912,7 @@ namespace CoefClasses
     }
   }
   
-  void CylFldCoefs::setMatrix(double time, CylFldStruct::dataType dat)
+  void CylFldCoefs::setMatrix(double time, CylFldStruct::dataType& dat)
   {
     auto it = coefs.find(roundTime(time));
 

--- a/expui/FieldBasis.H
+++ b/expui/FieldBasis.H
@@ -146,7 +146,7 @@ namespace BasisClasses
     //! Initialize accumulating coefficients from arrays.  This is
     //! called once to initialize the accumulation.
     void addFromArray
-    (Eigen::VectorXd& m, RowMatrixXd& p, bool roundrobin=true, bool posvelrows=false);
+    (Eigen::VectorXd m, RowMatrixXd p, bool roundrobin=true, bool posvelrows=false);
     
     //! Accumulate new coefficients
     virtual void accumulate(double mass,

--- a/expui/FieldBasis.H
+++ b/expui/FieldBasis.H
@@ -146,7 +146,7 @@ namespace BasisClasses
     //! Initialize accumulating coefficients from arrays.  This is
     //! called once to initialize the accumulation.
     void addFromArray
-    (Eigen::VectorXd m, RowMatrixXd p, bool roundrobin=true, bool posvelrows=false);
+    (Eigen::VectorXd& m, RowMatrixXd& p, bool roundrobin=true, bool posvelrows=false);
     
     //! Accumulate new coefficients
     virtual void accumulate(double mass,

--- a/expui/FieldBasis.cc
+++ b/expui/FieldBasis.cc
@@ -619,7 +619,7 @@ namespace BasisClasses
   }
 
   // Accumulate coefficient contributions from arrays
-  void FieldBasis::addFromArray(Eigen::VectorXd& m, RowMatrixXd& p,
+  void FieldBasis::addFromArray(Eigen::VectorXd m, RowMatrixXd p,
 				bool roundrobin, bool posvelrows)
   {
     // Sanity check: is coefficient instance created?  This is not

--- a/expui/FieldBasis.cc
+++ b/expui/FieldBasis.cc
@@ -619,7 +619,7 @@ namespace BasisClasses
   }
 
   // Accumulate coefficient contributions from arrays
-  void FieldBasis::addFromArray(Eigen::VectorXd m, RowMatrixXd p,
+  void FieldBasis::addFromArray(Eigen::VectorXd& m, RowMatrixXd& p,
 				bool roundrobin, bool posvelrows)
   {
     // Sanity check: is coefficient instance created?  This is not

--- a/exputil/BarrierWrapper.cc
+++ b/exputil/BarrierWrapper.cc
@@ -101,12 +101,13 @@ void BarrierWrapper::light_operator(const string& label,
 
 				// Compare adjacent strings in the list
     if (localid==0) {
-      char tmp[cbufsz];		// Working buffer
+				// Working buffer
+      auto tmp = std::make_unique<char[]>(cbufsz);
       bool firstime   = true;
-      string one, two = strncpy(tmp, &bufferT[0], cbufsz);
+      string one, two = strncpy(tmp.get(), &bufferT[0], cbufsz);
       for (int n=1; n<commsize; n++) {
 	one = two;
-	two = strncpy(tmp, &bufferT[cbufsz*n], cbufsz);
+	two = strncpy(tmp.get(), &bufferT[cbufsz*n], cbufsz);
 	if (one.compare(two) != 0) {
 	  if (firstime) {
 	    cout << std::string(60,'-') << std::endl << left

--- a/exputil/EmpCylSL.cc
+++ b/exputil/EmpCylSL.cc
@@ -5875,7 +5875,7 @@ void EmpCylSL::dump_images(const string& OUTFILE,
   //============
   // Open files
   //============
-  std::ofstream out[Number];
+  auto out = std::make_unique<std::ofstream[]>(Number);
   for (int j=0; j<Number; j++) {
     Name = OUTFILE + Types[j] + ".eof_recon";
     out[j].open(Name.c_str());

--- a/exputil/GaussCore.c
+++ b/exputil/GaussCore.c
@@ -26,19 +26,18 @@
 /*
    Forward declaration for function QQp:
 */
-static int QQp();
+static int QQp(double, double*, double*);
 
 /*
    Function to test a real value for exceeding -1,
    and quit on an error if condition not met.
 */
-void GaussCheck(value)
-double value;
+void GaussCheck(double value)
 {
-    if (value <= (-1.0)) {
-	fprintf(stderr, "Gauss package: parameter out of range: %g\n", value);
-	exit(1);
-    }
+  if (value <= (-1.0)) {
+    fprintf(stderr, "Gauss package: parameter out of range: %g\n", value);
+    exit(1);
+  }
 }
 
 
@@ -54,11 +53,8 @@ static int n1;
 /*
    The workhorse.
 */
-void GaussMaster(n, alpha, beta, conflag, abscis, weight)
-int n;
-double alpha, beta;
-int conflag;
-double abscis[], weight[];
+void GaussMaster(int n, double alpha, double beta, int conflag,
+		 double abscis[], double weight[])
 {
 #define FALSE 0
 #define  TRUE 1

--- a/exputil/GaussCore.h
+++ b/exputil/GaussCore.h
@@ -12,8 +12,10 @@
 #define   CONFLUENT 1
 #define NOCONFLUENT 0
 
-extern void GaussMaster();
-extern void GaussCheck();
+extern void GaussMaster(int n, double alpha, double beta, int conflag,
+			double abscis[], double weight[]);
+
+extern void GaussCheck(double value);
 
 /* ARGUMENT LISTS:
 

--- a/exputil/Hermite.c
+++ b/exputil/Hermite.c
@@ -23,9 +23,8 @@
 */
 #define odd(n) ((unsigned)(n) & 01)
 
-void Odd_Hermite(n, alpha, abscis, weight, w0)
-int n;
-double alpha, abscis[], weight[], *w0;
+void Odd_Hermite(int n, double alpha, double abscis[], double weight[],
+		 double* w0)
 {
     int k;
 
@@ -41,9 +40,7 @@ double alpha, abscis[], weight[], *w0;
 };
 
 
-void Even_Hermite(n, alpha, abscis, weight)
-int n;
-double alpha, abscis[], weight[];
+void Even_Hermite(int n, double alpha, double abscis[], double weight[])
 {
     int k;
 
@@ -59,9 +56,7 @@ double alpha, abscis[], weight[];
 };
 
 
-void Hermite(n, alpha, abscis, weight)
-int n;
-double alpha, abscis[], weight[];
+void Hermite(int n, double alpha, double abscis[], double weight[])
 {
     int n1, k;
 

--- a/exputil/Hermite.h
+++ b/exputil/Hermite.h
@@ -15,9 +15,12 @@
    Translation of module Hermite (export).
 */
 
-extern void Odd_Hermite();
-extern void Even_Hermite();
-extern void Hermite();
+extern void Odd_Hermite(int n, double alpha, double abscis[], double weight[],
+			double* w0);
+
+extern void Even_Hermite(int n, double alpha, double abscis[], double weight[]);
+
+extern void Hermite(int n, double alpha, double abscis[], double weight[]);
 
 /* ARGUMENT LISTS:
    

--- a/exputil/Jacobi.c
+++ b/exputil/Jacobi.c
@@ -20,10 +20,7 @@
 
 #define sqr(x) ((x)*(x))
 
-void Jacobi(n, alpha, beta, abscis, weight)
-int n;
-double alpha, beta;
-double abscis[], weight[];
+void Jacobi(int n, double alpha, double beta, double abscis[], double weight[])
 {
     int k;
 
@@ -34,10 +31,8 @@ double abscis[], weight[];
 }
 
 
-void Radau_Jacobi(n, alpha, beta, abscis, weight, leftw)
-int n;
-double alpha, beta;
-double abscis[], weight[], *leftw;
+void Radau_Jacobi(int n, double alpha, double beta,
+		  double abscis[], double weight[], double *leftw)
 {
     int k;
     double temp;
@@ -62,10 +57,9 @@ double abscis[], weight[], *leftw;
 };
 
 
-void Lobatto_Jacobi(n, alpha, beta, abscis, weight, leftw, rightw)
-int n;
-double alpha, beta;
-double abscis[], weight[], *leftw, *rightw;
+void Lobatto_Jacobi(int n, double alpha, double beta,
+		    double abscis[], double weight[],
+		    double* leftw, double* rightw)
 {
     int k;
     double temp1, temp2;

--- a/exputil/Jacobi.h
+++ b/exputil/Jacobi.h
@@ -15,10 +15,15 @@
    Translation of module Jacobi (export).
 */
 
+extern void Jacobi(int n, double alpha, double beta,
+		   double abscis[], double weight[]);
 
-extern void Jacobi();
-extern void Radau_Jacobi();
-extern void Lobatto_Jacobi();
+extern void Radau_Jacobi(int n, double alpha, double beta,
+			 double abscis[], double weight[], double *leftw);
+
+extern void Lobatto_Jacobi(int n, double alpha, double beta,
+			   double abscis[], double weight[],
+			   double* leftw, double* rightw);
 
 /* ARGUMENT LISTS:
    void Jacobi(n, alpha, beta, abscis, weight)

--- a/exputil/Laguerre.c
+++ b/exputil/Laguerre.c
@@ -15,18 +15,15 @@
 #include "GaussCore.h"
 #include "Laguerre.h"
 
-void Laguerre(n, alpha, abscis, weight)
-int n;
-double alpha, abscis[], weight[];
+void Laguerre(int n, double alpha, double abscis[], double weight[])
 {
     GaussCheck(alpha);
     GaussMaster(n, alpha, 0.0, CONFLUENT, abscis, weight);
 };
 
 
-void Radau_Laguerre(n, alpha, abscis, weight, leftw)
-int n;
-double alpha, abscis[], weight[], *leftw;
+void Radau_Laguerre(int n, double alpha, double abscis[], double weight[],
+		    double* leftw)
 {
     int k;
     double temp;

--- a/exputil/Laguerre.h
+++ b/exputil/Laguerre.h
@@ -15,8 +15,10 @@
    Translation of module Laguerre (export).
 */
 
-extern void Laguerre();
-extern void Radau_Laguerre();
+extern void Laguerre(int n, double alpha, double abscis[], double weight[]);
+
+extern void Radau_Laguerre(int n, double alpha,
+			   double abscis[], double weight[], double* leftw);
 
 /* 
    ARGUMENT LISTS:

--- a/exputil/ParticleReader.cc
+++ b/exputil/ParticleReader.cc
@@ -3,6 +3,7 @@
 #include <iomanip>
 #include <fstream>
 #include <sstream>
+#include <memory>
 #include <numeric>
 #include <string>
 #include <vector>
@@ -530,11 +531,11 @@ namespace PR {
 	    
 	    int rank = dataspace.getSimpleExtentNdims();
 	    
-	    hsize_t dims[rank];
+	    auto dims = std::make_unique<hsize_t[]>(rank);
 	    
-	    int ndims = dataspace.getSimpleExtentDims(dims, NULL);
+	    int ndims = dataspace.getSimpleExtentDims(dims.get(), NULL);
 	    
-	    H5::DataSpace mspace(rank, dims);
+	    H5::DataSpace mspace(rank, dims.get());
 	    
 	    std::vector<float> masses(dims[0]);
 	    dataset.read(&masses[0], H5::PredType::NATIVE_FLOAT, mspace, dataspace );
@@ -569,11 +570,11 @@ namespace PR {
 	  
 	  int rank = dataspace.getSimpleExtentNdims();
 	  
-	  hsize_t dims[rank];
+	  auto dims = std::make_unique<hsize_t[]>(rank);
 	  
-	  int ndims = dataspace.getSimpleExtentDims( dims, NULL);
+	  int ndims = dataspace.getSimpleExtentDims( dims.get(), NULL);
 	  
-	  H5::DataSpace mspace(rank, dims);
+	  H5::DataSpace mspace(rank, dims.get());
 	  
 	  std::vector<unsigned> seq(dims[0]);
 	  dataset.read(&seq[0], H5::PredType::NATIVE_UINT32, mspace, dataspace );

--- a/exputil/YamlConfig.cc
+++ b/exputil/YamlConfig.cc
@@ -71,7 +71,7 @@ cxxopts::ParseResult LoadConfig(cxxopts::Options& options,
   YAML::Node conf = YAML::LoadFile(config);
 
   int count = conf.size()*2+1, cnt = 1;
-  char* data[count];
+  std::vector<char*> data(count);
 
   data[0] = new char [11];
   strcpy(data[0], "LoadConfig"); // Emulate the caller name

--- a/include/DiskWithHalo.H
+++ b/include/DiskWithHalo.H
@@ -66,13 +66,13 @@ public:
     dur = dur1 + dur2;
   }
   
-  double get_mass(const double x1, const double x2, const double x3)
+  double get_mass(const double x1, const double x2, const double x3) override
   { return get_mass(sqrt(x1*x1 + x2*x2 + x3*x3)); }
   
-  double get_density(const double x1, const double x2, const double x3)
+  double get_density(const double x1, const double x2, const double x3) override
   { return get_density(sqrt(x1*x1 + x2*x2 + x3*x3)); }
   
-  double get_pot(const double x1, const double x2, const double x3)
+  double get_pot(const double x1, const double x2, const double x3) override
   { return get_pot(sqrt(x1*x1 + x2*x2 + x3*x3)); }
 
   // Addiional member functions

--- a/include/EXPini.H
+++ b/include/EXPini.H
@@ -87,8 +87,9 @@ cxxopts::ParseResult LoadConfig(cxxopts::Options& options,
 {
   YAML::Node conf = YAML::LoadFile(config);
 
-  int count = conf.size()*2+1, cnt = 1;
+  const int count = conf.size()*2+1;
   char* data[count];
+  int cnt = 1;
 
   data[0] = new char [11];
   strcpy(data[0], "LoadConfig"); // Emulate the caller name

--- a/include/EXPini.H
+++ b/include/EXPini.H
@@ -88,7 +88,7 @@ cxxopts::ParseResult LoadConfig(cxxopts::Options& options,
   YAML::Node conf = YAML::LoadFile(config);
 
   const int count = conf.size()*2+1;
-  char* data[count];
+  std::vector<char*> data(count);
   int cnt = 1;
 
   data[0] = new char [11];
@@ -131,7 +131,7 @@ cxxopts::ParseResult LoadConfig(cxxopts::Options& options,
   
   auto vm = options.parse(cnt, &data[0]);
 
-  for (int i=0; i<cnt; i++) delete [] data[i];
+  for (auto & v : data) delete [] v;
 
   return vm;
 }

--- a/include/SLGridMP2.H
+++ b/include/SLGridMP2.H
@@ -314,6 +314,9 @@ private:
     //! Constructor
     CoordMap(double H) : H(H) {}
   
+    //! Destructor
+    virtual ~CoordMap() {}
+
     //! Convert from vertical to mapped coordinate
     virtual double z_to_xi  (double z) = 0;
 

--- a/include/TransformFFT.H
+++ b/include/TransformFFT.H
@@ -2,11 +2,12 @@
 #ifndef _TransformFFT_h
 #define _TransformFFT_h
 
+#include <complex>
+#include <vector>
+
 #include <Eigen/Dense>
 #include <fftw3.h>
 
-#include <complex>
-#include <vector>
 
 class TransformFFT
 {
@@ -15,7 +16,7 @@ class TransformFFT
 
   fftw_plan p;
   std::vector<double> in;
-  fftw_complex* out;
+  std::vector<std::complex<double>> out;
 
  public:
   

--- a/include/massmodel.H
+++ b/include/massmodel.H
@@ -188,13 +188,13 @@ public:
   virtual double get_dpot2(const double) = 0;
   virtual void get_pot_dpot(const double, double&, double&) = 0;
   
-  double get_mass(const double x1, const double x2, const double x3)
+  double get_mass(const double x1, const double x2, const double x3) override
   { return get_mass(sqrt(x1*x1 + x2*x2 + x3*x3)); }
   
-  double get_density(const double x1, const double x2, const double x3)
+  double get_density(const double x1, const double x2, const double x3) override
   { return get_density(sqrt(x1*x1 + x2*x2 + x3*x3)); }
   
-  double get_pot(const double x1, const double x2, const double x3)
+  double get_pot(const double x1, const double x2, const double x3) override
   { return get_pot(sqrt(x1*x1 + x2*x2 + x3*x3)); }
   //@}
   

--- a/pyEXP/BasisWrappers.cc
+++ b/pyEXP/BasisWrappers.cc
@@ -2014,7 +2014,7 @@ void BasisFactoryClasses(py::module &m)
 	  std::tie(T, O) =
 	    BasisClasses::IntegrateOrbits(tinit, tfinal, h, ps, bfe, F, stride);
 
-	  py::array_t<float> ret = make_ndarray<float>(O);
+	  py::array_t<float> ret = make_ndarray3<float>(O);
 	  return std::tuple<Eigen::VectorXd, py::array_t<float>>(T, ret);
 	},
 	R"(

--- a/pyEXP/BasisWrappers.cc
+++ b/pyEXP/BasisWrappers.cc
@@ -286,7 +286,7 @@ void BasisFactoryClasses(py::module &m)
     }
 
     virtual void
-    addFromArray(Eigen::VectorXd m, RowMatrixXd p, bool roundrobin, bool posvelrows) override {
+    addFromArray(Eigen::VectorXd& m, RowMatrixXd& p, bool roundrobin, bool posvelrows) override {
       PYBIND11_OVERRIDE_PURE(void, Basis, addFromArray, m, p, roundrobin, posvelrows);
     }
   };
@@ -973,7 +973,7 @@ void BasisFactoryClasses(py::module &m)
          )",
 	 py::arg("center") = std::vector<double>(3, 0.0))
     .def("addFromArray",
-	 [](BasisClasses::BiorthBasis& A, Eigen::VectorXd mass, RowMatrixXd pos)
+	 [](BasisClasses::BiorthBasis& A, Eigen::VectorXd& mass, RowMatrixXd& pos)
 	 {
 	   return A.addFromArray(mass, pos);
 	 },
@@ -1804,7 +1804,7 @@ void BasisFactoryClasses(py::module &m)
          )",
 	 py::arg("center") = std::vector<double>(3, 0.0))
     .def("addFromArray",
-	 [](BasisClasses::FieldBasis& A, Eigen::VectorXd mass, RowMatrixXd ps)
+	 [](BasisClasses::FieldBasis& A, Eigen::VectorXd& mass, RowMatrixXd& ps)
 	 {
 	   return A.addFromArray(mass, ps);
 	 },

--- a/pyEXP/BasisWrappers.cc
+++ b/pyEXP/BasisWrappers.cc
@@ -286,7 +286,7 @@ void BasisFactoryClasses(py::module &m)
     }
 
     virtual void
-    addFromArray(Eigen::VectorXd& m, RowMatrixXd& p, bool roundrobin, bool posvelrows) override {
+    addFromArray(Eigen::VectorXd m, RowMatrixXd p, bool roundrobin, bool posvelrows) override {
       PYBIND11_OVERRIDE_PURE(void, Basis, addFromArray, m, p, roundrobin, posvelrows);
     }
   };
@@ -973,7 +973,7 @@ void BasisFactoryClasses(py::module &m)
          )",
 	 py::arg("center") = std::vector<double>(3, 0.0))
     .def("addFromArray",
-	 [](BasisClasses::BiorthBasis& A, Eigen::VectorXd& mass, RowMatrixXd& pos)
+	 [](BasisClasses::BiorthBasis& A, Eigen::VectorXd mass, RowMatrixXd pos)
 	 {
 	   return A.addFromArray(mass, pos);
 	 },
@@ -1804,7 +1804,7 @@ void BasisFactoryClasses(py::module &m)
          )",
 	 py::arg("center") = std::vector<double>(3, 0.0))
     .def("addFromArray",
-	 [](BasisClasses::FieldBasis& A, Eigen::VectorXd& mass, RowMatrixXd& ps)
+	 [](BasisClasses::FieldBasis& A, Eigen::VectorXd mass, RowMatrixXd ps)
 	 {
 	   return A.addFromArray(mass, ps);
 	 },

--- a/pyEXP/CoefWrappers.cc
+++ b/pyEXP/CoefWrappers.cc
@@ -155,7 +155,7 @@ void CoefficientClasses(py::module &m) {
       PYBIND11_OVERRIDE_PURE(Eigen::VectorXcd&, Coefs, getData, time);
     }
 
-    void setData(double time, const Eigen::VectorXcd& array) override {
+    void setData(double time, Eigen::Ref<Eigen::VectorXcd> array) override {
       PYBIND11_OVERRIDE_PURE(void, Coefs, setData, time, array);
     }
 
@@ -231,7 +231,7 @@ void CoefficientClasses(py::module &m) {
       PYBIND11_OVERRIDE(Eigen::VectorXcd&, SphCoefs, getData, time);
     }
 
-    void setData(double time, const Eigen::VectorXcd& array) override {
+    void setData(double time, Eigen::Ref<Eigen::VectorXcd> array) override {
       PYBIND11_OVERRIDE(void, SphCoefs, setData, time, array);
     }
 
@@ -310,7 +310,7 @@ void CoefficientClasses(py::module &m) {
       PYBIND11_OVERRIDE(Eigen::VectorXcd&, CylCoefs, getData, time);
     }
 
-    void setData(double time, const Eigen::VectorXcd& array) override {
+    void setData(double time, Eigen::Ref<Eigen::VectorXcd> array) override {
       PYBIND11_OVERRIDE(void, CylCoefs, setData, time, array);
     }
 
@@ -388,7 +388,7 @@ void CoefficientClasses(py::module &m) {
       PYBIND11_OVERRIDE(Eigen::VectorXcd&, SlabCoefs, getData, time);
     }
 
-    void setData(double time, const Eigen::VectorXcd& array) override {
+    void setData(double time, Eigen::Ref<Eigen::VectorXcd> array) override {
       PYBIND11_OVERRIDE(void, SlabCoefs, setData, time, array);
     }
 
@@ -467,7 +467,7 @@ void CoefficientClasses(py::module &m) {
       PYBIND11_OVERRIDE(Eigen::VectorXcd&, CubeCoefs, getData, time);
     }
 
-    void setData(double time, const Eigen::VectorXcd& array) override {
+    void setData(double time, Eigen::Ref<Eigen::VectorXcd> array) override {
       PYBIND11_OVERRIDE(void, CubeCoefs, setData, time, array);
     }
 
@@ -546,7 +546,7 @@ void CoefficientClasses(py::module &m) {
       PYBIND11_OVERRIDE(Eigen::VectorXcd&, TableData, getData, time);
     }
 
-    void setData(double time, const Eigen::VectorXcd& array) override {
+    void setData(double time, Eigen::Ref<Eigen::VectorXcd> array) override {
       PYBIND11_OVERRIDE(void, TableData, setData, time, array);
     }
 

--- a/pyEXP/CoefWrappers.cc
+++ b/pyEXP/CoefWrappers.cc
@@ -155,7 +155,7 @@ void CoefficientClasses(py::module &m) {
       PYBIND11_OVERRIDE_PURE(Eigen::VectorXcd&, Coefs, getData, time);
     }
 
-    void setData(double time, Eigen::Ref<Eigen::VectorXcd> array) override {
+    void setData(double time, Eigen::VectorXcd& array) override {
       PYBIND11_OVERRIDE_PURE(void, Coefs, setData, time, array);
     }
 
@@ -231,7 +231,7 @@ void CoefficientClasses(py::module &m) {
       PYBIND11_OVERRIDE(Eigen::VectorXcd&, SphCoefs, getData, time);
     }
 
-    void setData(double time, Eigen::Ref<Eigen::VectorXcd> array) override {
+    void setData(double time, Eigen::VectorXcd& array) override {
       PYBIND11_OVERRIDE(void, SphCoefs, setData, time, array);
     }
 
@@ -310,7 +310,7 @@ void CoefficientClasses(py::module &m) {
       PYBIND11_OVERRIDE(Eigen::VectorXcd&, CylCoefs, getData, time);
     }
 
-    void setData(double time, Eigen::Ref<Eigen::VectorXcd> array) override {
+    void setData(double time, Eigen::VectorXcd& array) override {
       PYBIND11_OVERRIDE(void, CylCoefs, setData, time, array);
     }
 
@@ -388,7 +388,7 @@ void CoefficientClasses(py::module &m) {
       PYBIND11_OVERRIDE(Eigen::VectorXcd&, SlabCoefs, getData, time);
     }
 
-    void setData(double time, Eigen::Ref<Eigen::VectorXcd> array) override {
+    void setData(double time, Eigen::VectorXcd& array) override {
       PYBIND11_OVERRIDE(void, SlabCoefs, setData, time, array);
     }
 
@@ -467,7 +467,7 @@ void CoefficientClasses(py::module &m) {
       PYBIND11_OVERRIDE(Eigen::VectorXcd&, CubeCoefs, getData, time);
     }
 
-    void setData(double time, Eigen::Ref<Eigen::VectorXcd> array) override {
+    void setData(double time, Eigen::VectorXcd& array) override {
       PYBIND11_OVERRIDE(void, CubeCoefs, setData, time, array);
     }
 
@@ -546,7 +546,7 @@ void CoefficientClasses(py::module &m) {
       PYBIND11_OVERRIDE(Eigen::VectorXcd&, TableData, getData, time);
     }
 
-    void setData(double time, Eigen::Ref<Eigen::VectorXcd> array) override {
+    void setData(double time, Eigen::VectorXcd& array) override {
       PYBIND11_OVERRIDE(void, TableData, setData, time, array);
     }
 
@@ -1185,7 +1185,7 @@ void CoefficientClasses(py::module &m) {
 	 [](CoefClasses::SphCoefs& A)
 	 {
 	   auto M = A.getAllCoefs(); // Need a copy here
-	   py::array_t<std::complex<double>> ret = make_ndarray<std::complex<double>>(M);
+	   py::array_t<std::complex<double>> ret = make_ndarray3<std::complex<double>>(M);
 	   return ret;
 	 },
 	 R"(
@@ -1260,7 +1260,7 @@ void CoefficientClasses(py::module &m) {
 	 [](CoefClasses::CylCoefs& A)
 	 {
 	   auto M = A.getAllCoefs(); // Need a copy here
-	   py::array_t<std::complex<double>> ret = make_ndarray<std::complex<double>>(M);
+	   py::array_t<std::complex<double>> ret = make_ndarray3<std::complex<double>>(M);
 	   return ret;
 	 },
 	 R"(
@@ -1321,11 +1321,11 @@ void CoefficientClasses(py::module &m) {
          SphFldCoefs instance
          )")
     .def("__call__",
-	 [](CoefClasses::SphFldCoefs& A, double t)
+	 [](CoefClasses::SphFldCoefs& A, double time)
 	 {
-	   Eigen::Tensor<std::complex<double>, 3> M = A.getMatrix(t);
-	   py::array_t<std::complex<double>> ret = make_ndarray<std::complex<double>>(M);
-	   return ret;
+	   // Need a copy here
+	   auto M = A.getMatrix(time);
+	   return make_ndarray3<std::complex<double>>(M);
 	 },
          R"(
          Return the coefficient tensor for the desired time.
@@ -1347,11 +1347,11 @@ void CoefficientClasses(py::module &m) {
          )",
          py::arg("time"))
     .def("setMatrix",
-	 [](CoefClasses::SphFldCoefs& A, double t,
-	    py::array_t<std::complex<double>> array)
+	 [](CoefClasses::SphFldCoefs& A, double time,
+	    py::array_t<std::complex<double>> mat)
 	 {
-	   auto M = make_tensor3<std::complex<double>>(array);
-	   A.setMatrix(t, M);
+	   auto M = make_tensor3<std::complex<double>>(mat);
+	   A.setMatrix(time, M);
 	 },
          R"(
          Enter and/or rewrite the coefficient tensor at the provided time
@@ -1406,11 +1406,10 @@ void CoefficientClasses(py::module &m) {
          CylFldCoefs instance
          )")
     .def("__call__",
-	 [](CoefClasses::CylFldCoefs& A, double t)
+	 [](CoefClasses::CylFldCoefs& A, double time)
 	 {
-	   Eigen::Tensor<std::complex<double>, 3> M = A.getMatrix(t);
-	   py::array_t<std::complex<double>> ret = make_ndarray<std::complex<double>>(M);
-	   return ret;
+	   auto M = A.getMatrix(time); // Need a copy here
+	   return make_ndarray3<std::complex<double>>(M);
 	 },
          R"(
          Return the coefficient tensor for the desired time.
@@ -1432,11 +1431,11 @@ void CoefficientClasses(py::module &m) {
          )",
          py::arg("time"))
     .def("setMatrix",
-	 [](CoefClasses::CylFldCoefs& A, double t,
-	    py::array_t<std::complex<double>> array)
+	 [](CoefClasses::CylFldCoefs& A, double time,
+	    py::array_t<std::complex<double>> mat)
 	 {
-	   auto M = make_tensor3<std::complex<double>>(array);
-	   A.setMatrix(t, M);
+	   auto M = make_tensor3<std::complex<double>>(mat);
+	   A.setMatrix(time, M);
 	 },
          R"(
          Enter and/or rewrite the coefficient tensor at the provided time

--- a/pyEXP/CoefWrappers.cc
+++ b/pyEXP/CoefWrappers.cc
@@ -155,7 +155,7 @@ void CoefficientClasses(py::module &m) {
       PYBIND11_OVERRIDE_PURE(Eigen::VectorXcd&, Coefs, getData, time);
     }
 
-    void setData(double time, Eigen::VectorXcd array) override {
+    void setData(double time, Eigen::VectorXcd& array) override {
       PYBIND11_OVERRIDE_PURE(void, Coefs, setData, time, array);
     }
 
@@ -231,7 +231,7 @@ void CoefficientClasses(py::module &m) {
       PYBIND11_OVERRIDE(Eigen::VectorXcd&, SphCoefs, getData, time);
     }
 
-    void setData(double time, Eigen::VectorXcd array) override {
+    void setData(double time, Eigen::VectorXcd& array) override {
       PYBIND11_OVERRIDE(void, SphCoefs, setData, time, array);
     }
 
@@ -310,7 +310,7 @@ void CoefficientClasses(py::module &m) {
       PYBIND11_OVERRIDE(Eigen::VectorXcd&, CylCoefs, getData, time);
     }
 
-    void setData(double time, Eigen::VectorXcd array) override {
+    void setData(double time, Eigen::VectorXcd& array) override {
       PYBIND11_OVERRIDE(void, CylCoefs, setData, time, array);
     }
 
@@ -388,7 +388,7 @@ void CoefficientClasses(py::module &m) {
       PYBIND11_OVERRIDE(Eigen::VectorXcd&, SlabCoefs, getData, time);
     }
 
-    void setData(double time, Eigen::VectorXcd array) override {
+    void setData(double time, Eigen::VectorXcd& array) override {
       PYBIND11_OVERRIDE(void, SlabCoefs, setData, time, array);
     }
 
@@ -467,7 +467,7 @@ void CoefficientClasses(py::module &m) {
       PYBIND11_OVERRIDE(Eigen::VectorXcd&, CubeCoefs, getData, time);
     }
 
-    void setData(double time, Eigen::VectorXcd array) override {
+    void setData(double time, Eigen::VectorXcd& array) override {
       PYBIND11_OVERRIDE(void, CubeCoefs, setData, time, array);
     }
 
@@ -546,7 +546,7 @@ void CoefficientClasses(py::module &m) {
       PYBIND11_OVERRIDE(Eigen::VectorXcd&, TableData, getData, time);
     }
 
-    void setData(double time, Eigen::VectorXcd array) override {
+    void setData(double time, Eigen::VectorXcd& array) override {
       PYBIND11_OVERRIDE(void, TableData, setData, time, array);
     }
 

--- a/pyEXP/CoefWrappers.cc
+++ b/pyEXP/CoefWrappers.cc
@@ -155,7 +155,7 @@ void CoefficientClasses(py::module &m) {
       PYBIND11_OVERRIDE_PURE(Eigen::VectorXcd&, Coefs, getData, time);
     }
 
-    void setData(double time, Eigen::VectorXcd& array) override {
+    void setData(double time, Eigen::VectorXcd array) override {
       PYBIND11_OVERRIDE_PURE(void, Coefs, setData, time, array);
     }
 
@@ -231,7 +231,7 @@ void CoefficientClasses(py::module &m) {
       PYBIND11_OVERRIDE(Eigen::VectorXcd&, SphCoefs, getData, time);
     }
 
-    void setData(double time, Eigen::VectorXcd& array) override {
+    void setData(double time, Eigen::VectorXcd array) override {
       PYBIND11_OVERRIDE(void, SphCoefs, setData, time, array);
     }
 
@@ -310,7 +310,7 @@ void CoefficientClasses(py::module &m) {
       PYBIND11_OVERRIDE(Eigen::VectorXcd&, CylCoefs, getData, time);
     }
 
-    void setData(double time, Eigen::VectorXcd& array) override {
+    void setData(double time, Eigen::VectorXcd array) override {
       PYBIND11_OVERRIDE(void, CylCoefs, setData, time, array);
     }
 
@@ -388,7 +388,7 @@ void CoefficientClasses(py::module &m) {
       PYBIND11_OVERRIDE(Eigen::VectorXcd&, SlabCoefs, getData, time);
     }
 
-    void setData(double time, Eigen::VectorXcd& array) override {
+    void setData(double time, Eigen::VectorXcd array) override {
       PYBIND11_OVERRIDE(void, SlabCoefs, setData, time, array);
     }
 
@@ -467,7 +467,7 @@ void CoefficientClasses(py::module &m) {
       PYBIND11_OVERRIDE(Eigen::VectorXcd&, CubeCoefs, getData, time);
     }
 
-    void setData(double time, Eigen::VectorXcd& array) override {
+    void setData(double time, Eigen::VectorXcd array) override {
       PYBIND11_OVERRIDE(void, CubeCoefs, setData, time, array);
     }
 
@@ -546,7 +546,7 @@ void CoefficientClasses(py::module &m) {
       PYBIND11_OVERRIDE(Eigen::VectorXcd&, TableData, getData, time);
     }
 
-    void setData(double time, Eigen::VectorXcd& array) override {
+    void setData(double time, Eigen::VectorXcd array) override {
       PYBIND11_OVERRIDE(void, TableData, setData, time, array);
     }
 

--- a/pyEXP/FieldWrappers.cc
+++ b/pyEXP/FieldWrappers.cc
@@ -196,7 +196,8 @@ void FieldGeneratorClasses(py::module &m) {
 
         See also
         --------
-        slices : generate fields in a surface slice given by the initializtion grid
+        slices : generate fields in a surface slice given by the
+                 initializtion grid
         volumes : generate fields in volume given by the initializtion grid
         )",
 	py::arg("basis"), py::arg("coefs"),
@@ -281,7 +282,8 @@ void FieldGeneratorClasses(py::module &m) {
 
         See also
         --------
-        slices : generate fields in a surface slice given by the initializtion grid
+        slices : generate fields in a surface slice given by the
+                 initializtion grid
         volumes : generate fields in volume given by the initializtion grid
         lines : generate fields along a line given by its end points
         )", 
@@ -314,7 +316,8 @@ void FieldGeneratorClasses(py::module &m) {
 
         See also
         --------
-        slices : generate fields in a surface slice given by the initializtion grid
+        slices : generate fields in a surface slice given by the
+                 initializtion grid
         volumes : generate fields in volume given by the initializtion grid
         lines : generate fields along a line given by its end points
         )",
@@ -329,7 +332,7 @@ void FieldGeneratorClasses(py::module &m) {
     auto vols = A.volumes(basis, coefs);
     for (auto & v : vols) {
       for (auto & u : v.second) {
-	ret[v.first][u.first] = make_ndarray<float>(u.second);
+	ret[v.first][u.first] = make_ndarray3<float>(u.second);
       }
     }
 

--- a/pyEXP/TensorToArray.H
+++ b/pyEXP/TensorToArray.H
@@ -3,7 +3,7 @@
 
 //! Helper function that maps the Eigen::Tensor<T, 3> into an numpy.ndarray
 template <typename T>
-py::array_t<T> make_ndarray(Eigen::Tensor<T, 3>& mat)
+py::array_t<T> make_ndarray3(Eigen::Tensor<T, 3>& mat)
 {
   // Get the tensor dimenions
   auto dims = mat.dimensions();
@@ -26,38 +26,6 @@ py::array_t<T> make_ndarray(Eigen::Tensor<T, 3>& mat)
      mat.data()
      );
 }
-
-template <typename T>
-Eigen::Tensor<T, 3> make_tensor3(py::array_t<T> array)
-{
-  // Request a buffer descriptor from Python
-  py::buffer_info buffer_info = array.request();
-
-  // Get the array dimenions
-  T *data = static_cast<T *>(buffer_info.ptr);
-  std::vector<ssize_t> shape = buffer_info.shape;
-
-  // Check rank
-  if (shape.size() != 3) {
-    std::ostringstream sout;
-    sout << "make_tensor3: tensor rank must be 3, found "
-	 << shape.size();
-    throw std::runtime_error(sout.str());
-  }
-
-  // Build result tensor with col-major ordering
-  Eigen::Tensor<T, 3> tensor(shape[0], shape[1], shape[2]);
-  for (int i=0, l=0; i < shape[0]; i++) {
-    for (int j=0; j < shape[1]; j++) {
-      for (int k=0; k < shape[2]; k++) {
-	tensor(i, j, k) = data[l++];
-      }
-    }
-  }
-
-  return tensor;
-}
-
 
 //! Helper function that maps the Eigen::Tensor<T, 4> into an numpy.ndarray
 template <typename T>
@@ -83,6 +51,40 @@ py::array_t<T> make_ndarray4(Eigen::Tensor<T, 4>& mat)
      // the data pointer
      mat.data()
      );
+}
+
+template <typename T>
+Eigen::Tensor<T, 3> make_tensor3(py::array_t<T>& in)
+{
+  // Request a buffer descriptor from Python
+  py::buffer_info buffer_info = in.request();
+
+  // Extract the data 
+  T *data = static_cast<T *>(buffer_info.ptr);
+
+  // Get the data shape
+  std::vector<ssize_t> shape = buffer_info.shape;
+
+  // Check rank
+  if (shape.size() != 3) {
+    std::ostringstream sout;
+    sout << "make_tensor3: tensor rank must be 3, found "
+	 << shape.size();
+    throw std::runtime_error(sout.str());
+  }
+
+  // Reorder the data to satisfy the col-major Eigen::Tensor ordering
+  //
+  Eigen::Tensor<T, 3> tensor(shape[0], shape[1], shape[2]);
+  for (int i=0, c=0; i < shape[0]; i++) {
+    for (int j=0; j < shape[1]; j++) {
+      for (int k=0; k < shape[2]; k++, c++) {
+	tensor(i, j, k) = data[c];
+      }
+    }
+  }
+
+  return tensor;
 }
 
 template <typename T>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -100,7 +100,7 @@ if(ENABLE_NBODY)
               PYTHONPATH=${CMAKE_BINARY_DIR}/pyEXP:$ENV{PYTHONPATH}
               ${PYTHON_EXECUTABLE} createCoefs.py
               WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/Halo")
-     set_tests_properties(pyEXPCoefCreateTest PROPERTIES LABELS "long")
+     set_tests_properties(pyEXPCoefCreateTest PROPERTIES LABELS "quick")
   endif()
 
   # A separate test to remove the generated files if they all exist;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -100,7 +100,7 @@ if(ENABLE_NBODY)
               PYTHONPATH=${CMAKE_BINARY_DIR}/pyEXP:$ENV{PYTHONPATH}
               ${PYTHON_EXECUTABLE} createCoefs.py
               WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/Halo")
-     set_tests_properties(pyEXPCoefCreateTest PROPERTIES LABELS "quick")
+     set_tests_properties(pyEXPCoefCreateTest PROPERTIES LABELS "long")
   endif()
 
   # A separate test to remove the generated files if they all exist;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -73,7 +73,7 @@ if(ENABLE_NBODY)
     ${PYTHON_EXECUTABLE} check.py
     WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/Halo)
 
-  set_tests_properties(expNbodyCheck2TW PROPERTIES DEPENDS expNbodyTest)
+  set_tests_properties(expNbodyCheck2TW PROPERTIES DEPENDS expNbodyTest LABELS "long")
 
   # This adds a coefficient read test using pyEXP only if
   # expNbodyTest is run and pyEXP has been built
@@ -84,23 +84,21 @@ if(ENABLE_NBODY)
               PYTHONPATH=${CMAKE_BINARY_DIR}/pyEXP:$ENV{PYTHONPATH}
               ${PYTHON_EXECUTABLE} readCoefs.py
               WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/Halo")
-     set_tests_properties(pyEXPCoefReadTest PROPERTIES DEPENDS expNbodyTest)
-     set_tests_properties(pyEXPCoefReadTest PROPERTIES LABELS "long")
+     set_tests_properties(pyEXPCoefReadTest PROPERTIES DEPENDS expNbodyTest LABELS "long")
 
      add_test(NAME pyEXPCoefMatrixTest
               COMMAND ${CMAKE_COMMAND} -E env
               PYTHONPATH=${CMAKE_BINARY_DIR}/pyEXP:$ENV{PYTHONPATH}
               ${PYTHON_EXECUTABLE} changeCoefs.py
               WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/Halo")
-     set_tests_properties(pyEXPCoefMatrixTest PROPERTIES DEPENDS expNbodyTest)
-     set_tests_properties(pyEXPCoefMatrixTest PROPERTIES LABELS "long")
+     set_tests_properties(pyEXPCoefMatrixTest PROPERTIES DEPENDS expNbodyTest LABELS "long")
 
      add_test(NAME pyEXPCoefCreateTest
               COMMAND ${CMAKE_COMMAND} -E env
               PYTHONPATH=${CMAKE_BINARY_DIR}/pyEXP:$ENV{PYTHONPATH}
               ${PYTHON_EXECUTABLE} createCoefs.py
               WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/Halo")
-     set_tests_properties(pyEXPCoefCreateTest PROPERTIES LABELS "quit")
+     set_tests_properties(pyEXPCoefCreateTest PROPERTIES LABELS "quick")
   endif()
 
   # A separate test to remove the generated files if they all exist;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -73,10 +73,10 @@ if(ENABLE_NBODY)
     ${PYTHON_EXECUTABLE} check.py
     WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/Halo)
 
-  set_tests_properties(expNbodyCheck2TW PROPERTIES DEPENDS makeNbodyTest)
+  set_tests_properties(expNbodyCheck2TW PROPERTIES DEPENDS expNbodyTest)
 
   # This adds a coefficient read test using pyEXP only if
-  # makeNbodyTest is run and pyEXP has been built
+  # expNbodyTest is run and pyEXP has been built
   if(ENABLE_PYEXP)
      # Read coefficient file with pyEXP
      add_test(NAME pyEXPCoefReadTest
@@ -84,8 +84,23 @@ if(ENABLE_NBODY)
               PYTHONPATH=${CMAKE_BINARY_DIR}/pyEXP:$ENV{PYTHONPATH}
               ${PYTHON_EXECUTABLE} readCoefs.py
               WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/Halo")
-     set_tests_properties(pyEXPCoefReadTest PROPERTIES DEPENDS makeNbodyTest)
+     set_tests_properties(pyEXPCoefReadTest PROPERTIES DEPENDS expNbodyTest)
      set_tests_properties(pyEXPCoefReadTest PROPERTIES LABELS "long")
+
+     add_test(NAME pyEXPCoefMatrixTest
+              COMMAND ${CMAKE_COMMAND} -E env
+              PYTHONPATH=${CMAKE_BINARY_DIR}/pyEXP:$ENV{PYTHONPATH}
+              ${PYTHON_EXECUTABLE} changeCoefs.py
+              WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/Halo")
+     set_tests_properties(pyEXPCoefMatrixTest PROPERTIES DEPENDS expNbodyTest)
+     set_tests_properties(pyEXPCoefMatrixTest PROPERTIES LABELS "long")
+
+     add_test(NAME pyEXPCoefCreateTest
+              COMMAND ${CMAKE_COMMAND} -E env
+              PYTHONPATH=${CMAKE_BINARY_DIR}/pyEXP:$ENV{PYTHONPATH}
+              ${PYTHON_EXECUTABLE} createCoefs.py
+              WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/Halo")
+     set_tests_properties(pyEXPCoefCreateTest PROPERTIES LABELS "quit")
   endif()
 
   # A separate test to remove the generated files if they all exist;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,7 @@
 include(CTest)
 
+set(CTEST_OUTPUT_ON_FAILURE ON)
+
 # Is EXP configured for pyEXP? If yes, run pyEXP tests...
 #
 if(ENABLE_PYEXP)

--- a/tests/Halo/changeCoefs.py
+++ b/tests/Halo/changeCoefs.py
@@ -1,0 +1,67 @@
+import os
+import pyEXP
+import numpy as np
+
+# Read the coefs from the file created by the expNbodyTest
+#
+coefs = pyEXP.coefs.Coefs.factory('outcoef.halo.run0')
+
+print("Got coefs for name=", coefs.getName())
+
+
+times = coefs.Times()
+data  = coefs.getAllCoefs()
+
+print("The data sizes and coefficient orders are:")
+print("M orders, N orders, Times:", data.shape)
+
+
+# Make the halo basis config
+config="""
+---
+id : sphereSL
+parameters :
+  numr: 4000
+  rmin: 0.0001
+  rmax: 1.95
+  Lmax: 2
+  nmax: 10
+  rmapping : 0.0667
+  self_consistent: true
+  modelname: SLGridSph.model
+  cachename: SLGridSph.cache.run0
+...
+"""
+
+# Construct the basis instances
+#
+basis = pyEXP.basis.Basis.factory(config)
+
+# Let's zero all of the odd order data
+#
+for k in range(data.shape[0]):
+    l, m = pyEXP.basis.SphericalSL.invI(k)
+    if l%2!=0 or m%2!=0: data[k,:,:] *= 0.0
+
+# Reset the coefficient data
+#
+for i in range(data.shape[2]):
+    coefs.setMatrix(times[i], data[:,:,i])
+
+# Check that odd coefficients are really zero
+data1 = coefs.getAllCoefs()
+minZero =  1.0e30
+maxZero = -1.0e30
+for k in range(data1.shape[0]):
+    l, m = pyEXP.basis.SphericalSL.invI(k)
+    if l%2!=0 or m%2!=0:
+        for v in data1[k,:,:].flatten():
+           minZero = min([minZero, abs(v)])
+           maxZero = max([maxZero, abs(v)])
+
+print('Zero test: min, max: {:13.7e}, {:13.7e}'.format(minZero, maxZero))
+
+if minZero < -1.0e-18 or maxZero > 1.0e-18:
+    exit(1)
+else:
+    exit(0)

--- a/tests/Halo/createCoefs.py
+++ b/tests/Halo/createCoefs.py
@@ -70,4 +70,4 @@ coefs.add(coef3)
 coefs.add(coef4)
 print("Times:", coefs.Times())
 
-exit(1)
+exit(0)

--- a/tests/Halo/createCoefs.py
+++ b/tests/Halo/createCoefs.py
@@ -1,4 +1,4 @@
-import os
+import os, time
 import pyEXP
 import random
 import numpy as np
@@ -27,11 +27,15 @@ basis = pyEXP.basis.Basis.factory(config)
 
 print("---- created basis")
 
+time.sleep(1)
+
 # Create a coefficient structure
 #
 coefs = pyEXP.coefs.SphCoefs(True)
 
 print("---- created coefficients")
+
+time.sleep(1)
 
 # Call the basis to generate coefficients
 #
@@ -48,8 +52,9 @@ for i in range(0, 100):
     zpos.append(random.random()*2.0 - 1.0)
 
 print("---- createFromArray usings lists")
+time.sleep(1)
 coef1 = basis.createFromArray(mass, [xpos, ypos, zpos], time=3.0)
-
+time.sleep(1)
 coefs.add(coef1)
 
 print("Times:", coefs.Times())

--- a/tests/Halo/createCoefs.py
+++ b/tests/Halo/createCoefs.py
@@ -47,8 +47,6 @@ for i in range(0, 100):
 print("---- createFromArray usings lists")
 coef1 = basis.createFromArray(mass, [xpos, ypos, zpos], time=3.0)
 
-exit(0)
-
 mass  = np.array(mass)
 data  = np.array([xpos, ypos, zpos])
 

--- a/tests/Halo/createCoefs.py
+++ b/tests/Halo/createCoefs.py
@@ -35,50 +35,54 @@ print("---- created coefficients")
 
 # Call the basis to generate coefficients
 #
-mass1 = []
-xpos1 = []
-ypos1 = []
-zpos1 = []
+mass = []
+xpos = []
+ypos = []
+zpos = []
 
 print("---- creating list data")
 for i in range(0, 100):
-    mass1.append(0.001)
-    xpos1.append(random.random()*2.0 - 1.0)
-    ypos1.append(random.random()*2.0 - 1.0)
-    zpos1.append(random.random()*2.0 - 1.0)
+    mass.append(0.01)
+    xpos.append(random.random()*2.0 - 1.0)
+    ypos.append(random.random()*2.0 - 1.0)
+    zpos.append(random.random()*2.0 - 1.0)
 
 print("---- createFromArray usings lists")
-coef1 = basis.createFromArray(mass1, [xpos1, ypos1, zpos1], time=3.0)
+coef1 = basis.createFromArray(mass, [xpos, ypos, zpos], time=3.0)
 
 coefs.add(coef1)
 
 print("---- creating array data from list data")
 
-mass2 = np.array(mass1)
-data2 = np.array([xpos1, ypos1, zpos1])
+# Note: this overwrites mass and data variables.  But data is now
+# passed by rference so pybind11 should have copies and not break the
+# references though garbage collection on the Python side
+#
+mass = np.array(mass)
+data = np.array([xpos, ypos, zpos])
 
 print("---- createFromArray usings numpy arrays converted from lists")
-coef2 = basis.createFromArray(mass2, data2, time=3.1)
+coef2 = basis.createFromArray(mass, data, time=3.1)
 
 coefs.add(coef2)
 
 print("---- creating array data from list of numpy arrays")
 
-mass3 = np.ones(1000) * 1.0e6
-xpos3 = np.random.normal(0.0, 1.0, 1000)
-ypos3 = np.random.normal(0.0, 1.0, 1000)
-zpos3 = np.random.normal(0.0, 1.0, 1000)
+mass = np.ones(100) * 1.0e-02
+xpos = np.random.normal(0.0, 1.0, 100)
+ypos = np.random.normal(0.0, 1.0, 100)
+zpos = np.random.normal(0.0, 1.0, 100)
 
 print("---- createFromArray using a list of numpy arrays")
-coef3 = basis.createFromArray(mass3, [xpos3, ypos3, zpos3], time=3.2)
+coef3 = basis.createFromArray(mass, [xpos, ypos, zpos], time=3.2)
 
 coefs.add(coef3)
 
-data4  = np.array([xpos3, ypos3, zpos3])
-print("---- position data shape is:", data4.shape)
+data  = np.array([xpos, ypos, zpos])
+print("---- position data shape is:", data.shape)
 
 print("---- createFromArray usings pure numpy arrays")
-coef4 = basis.createFromArray(mass3, data4, time=3.3)
+coef4 = basis.createFromArray(mass, data, time=3.3)
 
 coefs.add(coef4)
 

--- a/tests/Halo/createCoefs.py
+++ b/tests/Halo/createCoefs.py
@@ -1,4 +1,4 @@
-import os, time
+import os
 import pyEXP
 import random
 import numpy as np
@@ -27,15 +27,11 @@ basis = pyEXP.basis.Basis.factory(config)
 
 print("---- created basis")
 
-time.sleep(1)
-
 # Create a coefficient structure
 #
 coefs = pyEXP.coefs.SphCoefs(True)
 
 print("---- created coefficients")
-
-time.sleep(1)
 
 # Call the basis to generate coefficients
 #
@@ -52,14 +48,12 @@ for i in range(0, 100):
     zpos.append(random.random()*2.0 - 1.0)
 
 print("---- createFromArray usings lists")
-time.sleep(1)
+
 coef1 = basis.createFromArray(mass, [xpos, ypos, zpos], time=3.0)
-time.sleep(1)
+
 coefs.add(coef1)
 
 print("Times:", coefs.Times())
-
-exit(0)
 
 print("---- creating array data from list data")
 

--- a/tests/Halo/createCoefs.py
+++ b/tests/Halo/createCoefs.py
@@ -58,29 +58,30 @@ coef2 = basis.createFromArray(mass2, data2, time=3.1)
 
 coefs.add(coef2)
 
-print("Times:", coefs.Times())
-exit(0) # TEST END
-
-mass = np.ones(1000) * 1.0e6
-xpos = np.random.normal(0.0, 1.0, 1000)
-ypos = np.random.normal(0.0, 1.0, 1000)
-zpos = np.random.normal(0.0, 1.0, 1000)
+mass3 = np.ones(1000) * 1.0e6
+xpos3 = np.random.normal(0.0, 1.0, 1000)
+ypos3 = np.random.normal(0.0, 1.0, 1000)
+zpos3 = np.random.normal(0.0, 1.0, 1000)
 
 print("---- createFromArray using a list of numpy arrays")
-coef3 = basis.createFromArray(mass, [xpos, ypos, zpos], time=3.2)
+coef3 = basis.createFromArray(mass3, [xpos3, ypos3, zpos3], time=3.2)
 
-data  = np.array([xpos, ypos, zpos])
+coefs.add(coef3)
+
+data4  = np.array([xpos3, ypos3, zpos3])
 
 print("---- createFromArray usings pure numpy arrays")
-coef4 = basis.createFromArray(mass, data, time=3.3)
+coef4 = basis.createFromArray(mass3, data4, time=3.3)
+
+coefs.add(coef4)
 
 # Add the coefficient structure coefficient structure
 #
-coefs = pyEXP.coefs.SphCoefs(True)
-coefs.add(coef1)
-coefs.add(coef2)
-coefs.add(coef3)
-coefs.add(coef4)
+# coefs = pyEXP.coefs.SphCoefs(True)
+# coefs.add(coef1)
+# coefs.add(coef2)
+# coefs.add(coef3)
+# coefs.add(coef4)
 print("Times:", coefs.Times())
 
 exit(0)

--- a/tests/Halo/createCoefs.py
+++ b/tests/Halo/createCoefs.py
@@ -70,4 +70,4 @@ coefs.add(coef3)
 coefs.add(coef4)
 print("Times:", coefs.Times())
 
-exit(0)
+exit(1)

--- a/tests/Halo/createCoefs.py
+++ b/tests/Halo/createCoefs.py
@@ -1,0 +1,46 @@
+import os
+import pyEXP
+import numpy as np
+
+# Make the halo basis config
+config="""
+---
+id : sphereSL
+parameters :
+  numr: 4000
+  rmin: 0.0001
+  rmax: 1.95
+  Lmax: 2
+  nmax: 10
+  rmapping : 0.0667
+  self_consistent: true
+  modelname: SLGridSph.model
+  cachename: SLGridSph.cache.run0
+...
+"""
+
+# Construct the basis instances
+#
+basis = pyEXP.basis.Basis.factory(config)
+
+# Open the file and read the array.  The file was generated using
+# psp2ascii.
+#
+bodyfile = 'new.bods'
+if not os.path.exists(bodyfile):
+    print('Body file <{}> does not exist'.format(bodyfile))
+    exit(1)
+
+data = np.loadtxt(bodyfile, skiprows=1, usecols=(1, 2, 3, 4))
+print(data.shape)
+
+# Call the basis to generate coefficients
+#
+coef = basis.createFromArray(data[:,0], data[:,1:4], time=3.0)
+
+# Add the coefficient structure coefficient structure
+coefs = pyEXP.coefs.SphCoefs(True)
+coefs.add(coef)
+print("Times:", coefs.Times())
+
+exit(0)

--- a/tests/Halo/createCoefs.py
+++ b/tests/Halo/createCoefs.py
@@ -27,8 +27,11 @@ basis = pyEXP.basis.Basis.factory(config)
 
 print("---- created basis")
 
-# Make some fake body data
+# Create a coefficient structure
 #
+coefs = pyEXP.coefs.SphCoefs(True)
+
+print("---- created coefficients")
 
 # Call the basis to generate coefficients
 #
@@ -47,8 +50,9 @@ for i in range(0, 100):
 print("---- createFromArray usings lists")
 coef1 = basis.createFromArray(mass1, [xpos1, ypos1, zpos1], time=3.0)
 
-coefs = pyEXP.coefs.SphCoefs(True)
 coefs.add(coef1)
+
+print("---- creating array data from list data")
 
 mass2 = np.array(mass1)
 data2 = np.array([xpos1, ypos1, zpos1])
@@ -57,6 +61,8 @@ print("---- createFromArray usings numpy arrays converted from lists")
 coef2 = basis.createFromArray(mass2, data2, time=3.1)
 
 coefs.add(coef2)
+
+print("---- creating array data from list of numpy arrays")
 
 mass3 = np.ones(1000) * 1.0e6
 xpos3 = np.random.normal(0.0, 1.0, 1000)
@@ -69,19 +75,15 @@ coef3 = basis.createFromArray(mass3, [xpos3, ypos3, zpos3], time=3.2)
 coefs.add(coef3)
 
 data4  = np.array([xpos3, ypos3, zpos3])
+print("---- position data shape is:", data4.shape)
 
 print("---- createFromArray usings pure numpy arrays")
 coef4 = basis.createFromArray(mass3, data4, time=3.3)
 
 coefs.add(coef4)
 
-# Add the coefficient structure coefficient structure
+# Check the coefficient structure for the 4 added times
 #
-# coefs = pyEXP.coefs.SphCoefs(True)
-# coefs.add(coef1)
-# coefs.add(coef2)
-# coefs.add(coef3)
-# coefs.add(coef4)
 print("Times:", coefs.Times())
 
 exit(0)

--- a/tests/Halo/createCoefs.py
+++ b/tests/Halo/createCoefs.py
@@ -32,32 +32,34 @@ print("---- created basis")
 
 # Call the basis to generate coefficients
 #
-mass = []
-xpos = []
-ypos = []
-zpos = []
+mass1 = []
+xpos1 = []
+ypos1 = []
+zpos1 = []
 
 print("---- creating list data")
 for i in range(0, 100):
-    mass.append(0.001)
-    xpos.append(random.random()*2.0 - 1.0)
-    ypos.append(random.random()*2.0 - 1.0)
-    zpos.append(random.random()*2.0 - 1.0)
+    mass1.append(0.001)
+    xpos1.append(random.random()*2.0 - 1.0)
+    ypos1.append(random.random()*2.0 - 1.0)
+    zpos1.append(random.random()*2.0 - 1.0)
 
 print("---- createFromArray usings lists")
-coef1 = basis.createFromArray(mass, [xpos, ypos, zpos], time=3.0)
+coef1 = basis.createFromArray(mass1, [xpos1, ypos1, zpos1], time=3.0)
 
 coefs = pyEXP.coefs.SphCoefs(True)
 coefs.add(coef1)
 
-print("Times:", coefs.Times())
-exit(0) # TEST END
-
-mass  = np.array(mass)
-data  = np.array([xpos, ypos, zpos])
+mass2 = np.array(mass1)
+data2 = np.array([xpos1, ypos1, zpos1])
 
 print("---- createFromArray usings numpy arrays converted from lists")
-coef2 = basis.createFromArray(mass, data, time=3.1)
+coef2 = basis.createFromArray(mass2, data2, time=3.1)
+
+coefs.add(coef2)
+
+print("Times:", coefs.Times())
+exit(0) # TEST END
 
 mass = np.ones(1000) * 1.0e6
 xpos = np.random.normal(0.0, 1.0, 1000)

--- a/tests/Halo/createCoefs.py
+++ b/tests/Halo/createCoefs.py
@@ -27,6 +27,8 @@ basis = pyEXP.basis.Basis.factory(config)
 
 print("---- created basis")
 
+exit(0)
+
 # Make some fake body data
 #
 

--- a/tests/Halo/createCoefs.py
+++ b/tests/Halo/createCoefs.py
@@ -27,8 +27,6 @@ basis = pyEXP.basis.Basis.factory(config)
 
 print("---- created basis")
 
-exit(0)
-
 # Make some fake body data
 #
 
@@ -45,6 +43,8 @@ for i in range(0, 100):
     xpos.append(random.random()*2.0 - 1.0)
     ypos.append(random.random()*2.0 - 1.0)
     zpos.append(random.random()*2.0 - 1.0)
+
+exit(0)
 
 print("---- createFromArray usings lists")
 coef1 = basis.createFromArray(mass, [xpos, ypos, zpos], time=3.0)

--- a/tests/Halo/createCoefs.py
+++ b/tests/Halo/createCoefs.py
@@ -1,5 +1,6 @@
 import os
 import pyEXP
+import random
 import numpy as np
 
 # Make the halo basis config
@@ -23,24 +24,50 @@ parameters :
 #
 basis = pyEXP.basis.Basis.factory(config)
 
-# Open the file and read the array.  The file was generated using
-# psp2ascii.
+# Make some fake body data
 #
-bodyfile = 'new.bods'
-if not os.path.exists(bodyfile):
-    print('Body file <{}> does not exist'.format(bodyfile))
-    exit(1)
-
-data = np.loadtxt(bodyfile, skiprows=1, usecols=(1, 2, 3, 4))
-print(data.shape)
 
 # Call the basis to generate coefficients
 #
-coef = basis.createFromArray(data[:,0], data[:,1:4], time=3.0)
+mass = []
+xpos = []
+ypos = []
+zpos = []
+
+for i in range(0,100):
+    mass.append(0.001)
+    xpos.append(random.random()*2.0 - 1.0)
+    ypos.append(random.random()*2.0 - 1.0)
+    zpos.append(random.random()*2.0 - 1.0)
+
+print("---- createFromArray usings lists")
+coef1 = basis.createFromArray(mass, [xpos, ypos, zpos], time=3.0)
+
+mass  = np.array(mass)
+data  = np.array([xpos, ypos, zpos])
+
+print("---- createFromArray usings numpy arrays converted from lists")
+coef2 = basis.createFromArray(mass, data, time=3.1)
+
+mass = np.ones(1000) * 1.0e6
+xpos = np.random.normal(0.0, 1.0, 1000)
+ypos = np.random.normal(0.0, 1.0, 1000)
+zpos = np.random.normal(0.0, 1.0, 1000)
+
+print("---- createFromArray using a list of numpy arrays")
+coef3 = basis.createFromArray(mass, [xpos, ypos, zpos], time=3.2)
+
+data  = np.array([xpos, ypos, zpos])
+
+print("---- createFromArray usings pure numpy arrays")
+coef4 = basis.createFromArray(mass, data, time=3.3)
 
 # Add the coefficient structure coefficient structure
 coefs = pyEXP.coefs.SphCoefs(True)
-coefs.add(coef)
+coefs.add(coef1)
+coefs.add(coef2)
+coefs.add(coef3)
+coefs.add(coef4)
 print("Times:", coefs.Times())
 
 exit(0)

--- a/tests/Halo/createCoefs.py
+++ b/tests/Halo/createCoefs.py
@@ -44,10 +44,10 @@ for i in range(0, 100):
     ypos.append(random.random()*2.0 - 1.0)
     zpos.append(random.random()*2.0 - 1.0)
 
-exit(0)
-
 print("---- createFromArray usings lists")
 coef1 = basis.createFromArray(mass, [xpos, ypos, zpos], time=3.0)
+
+exit(0)
 
 mass  = np.array(mass)
 data  = np.array([xpos, ypos, zpos])

--- a/tests/Halo/createCoefs.py
+++ b/tests/Halo/createCoefs.py
@@ -37,8 +37,6 @@ print("---- created coefficients")
 
 time.sleep(1)
 
-exit(0)
-
 # Call the basis to generate coefficients
 #
 mass = []

--- a/tests/Halo/createCoefs.py
+++ b/tests/Halo/createCoefs.py
@@ -34,7 +34,8 @@ xpos = []
 ypos = []
 zpos = []
 
-for i in range(0,100):
+print("---- creating list data")
+for i in range(0, 100):
     mass.append(0.001)
     xpos.append(random.random()*2.0 - 1.0)
     ypos.append(random.random()*2.0 - 1.0)

--- a/tests/Halo/createCoefs.py
+++ b/tests/Halo/createCoefs.py
@@ -52,6 +52,10 @@ coef1 = basis.createFromArray(mass, [xpos, ypos, zpos], time=3.0)
 
 coefs.add(coef1)
 
+print("Times:", coefs.Times())
+
+exit(0)
+
 print("---- creating array data from list data")
 
 # Note: this overwrites mass and data variables.  But data is now

--- a/tests/Halo/createCoefs.py
+++ b/tests/Halo/createCoefs.py
@@ -14,15 +14,18 @@ parameters :
   Lmax: 2
   nmax: 10
   rmapping : 0.0667
-  self_consistent: true
   modelname: SLGridSph.model
   cachename: SLGridSph.cache.run0
 ...
 """
 
+print("---- about to create basis")
+
 # Construct the basis instances
 #
 basis = pyEXP.basis.Basis.factory(config)
+
+print("---- created basis")
 
 # Make some fake body data
 #

--- a/tests/Halo/createCoefs.py
+++ b/tests/Halo/createCoefs.py
@@ -37,6 +37,8 @@ print("---- created coefficients")
 
 time.sleep(1)
 
+exit(0)
+
 # Call the basis to generate coefficients
 #
 mass = []

--- a/tests/Halo/createCoefs.py
+++ b/tests/Halo/createCoefs.py
@@ -47,7 +47,11 @@ for i in range(0, 100):
 print("---- createFromArray usings lists")
 coef1 = basis.createFromArray(mass, [xpos, ypos, zpos], time=3.0)
 
-exit(0) # TEST
+coefs = pyEXP.coefs.SphCoefs(True)
+coefs.add(coef1)
+
+print("Times:", coefs.Times())
+exit(0) # TEST END
 
 mass  = np.array(mass)
 data  = np.array([xpos, ypos, zpos])

--- a/tests/Halo/createCoefs.py
+++ b/tests/Halo/createCoefs.py
@@ -47,6 +47,8 @@ for i in range(0, 100):
 print("---- createFromArray usings lists")
 coef1 = basis.createFromArray(mass, [xpos, ypos, zpos], time=3.0)
 
+exit(0) # TEST
+
 mass  = np.array(mass)
 data  = np.array([xpos, ypos, zpos])
 

--- a/utils/Analysis/gas2dcyl.cc
+++ b/utils/Analysis/gas2dcyl.cc
@@ -171,9 +171,9 @@ main(int argc, char **argv)
       char *c = const_cast<char*>(files[n].c_str());
       MPI_Bcast(c, sz+1, MPI_CHAR, 0, MPI_COMM_WORLD);
     } else {
-      char l[sz+1];
-      MPI_Bcast(&l[0], sz+1, MPI_CHAR, 0, MPI_COMM_WORLD);
-      files.push_back(l);
+      auto l = std::make_unique<char[]>(sz+1);
+      MPI_Bcast(l.get(), sz+1, MPI_CHAR, 0, MPI_COMM_WORLD);
+      files.push_back(l.get());
     }
     MPI_Barrier(MPI_COMM_WORLD);
   }

--- a/utils/Analysis/psphisto.cc
+++ b/utils/Analysis/psphisto.cc
@@ -34,8 +34,9 @@
 #include <iomanip>
 #include <fstream>
 #include <sstream>
-#include <cmath>
+#include <memory>
 #include <string>
+#include <cmath>
 
                                 // System libs
 #include <sys/time.h>
@@ -177,9 +178,9 @@ main(int argc, char **argv)
       char *c = const_cast<char*>(files[n].c_str());
       MPI_Bcast(c, sz+1, MPI_CHAR, 0, MPI_COMM_WORLD);
     } else {
-      char l[sz+1];
-      MPI_Bcast(&l[0], sz+1, MPI_CHAR, 0, MPI_COMM_WORLD);
-      files.push_back(l);
+      auto l = std::make_unique<char[]>(sz+1);
+      MPI_Bcast(l.get(), sz+1, MPI_CHAR, 0, MPI_COMM_WORLD);
+      files.push_back(l.get());
     }
     MPI_Barrier(MPI_COMM_WORLD);
   }

--- a/utils/ICs/SphericalSL.cc
+++ b/utils/ICs/SphericalSL.cc
@@ -245,7 +245,7 @@ void SphericalSL::compute_coefficients_single(vector<Particle> &part)
 
 void SphericalSL::compute_coefficients_thread(vector<Particle>& part)
 {
-  std::thread t[nthrds];
+  std::vector<std::thread> t(nthrds);
  
   // Launch the threads
   for (int id=0; id<nthrds; ++id) {

--- a/utils/ICs/gensph.cc
+++ b/utils/ICs/gensph.cc
@@ -355,13 +355,13 @@ main(int argc, char **argv)
 #ifdef HAVE_FFTW
     if (SMOOTH>0.0) {
 
-      double a[NUMR], b[NUMR], c[NUMR];
-      fftw_complex A[NUMR], B[NUMR], C[NUMR];
+      std::vector<double> a(NUMR), b(NUMR), c(NUMR);
+      std::vector<fftw_complex> A(NUMR), B(NUMR), C(NUMR);
       fftw_plan pa, pb, pinv;
 
-      pa   = fftw_plan_dft_r2c_1d(NUMR, a, A, FFTW_ESTIMATE);
-      pb   = fftw_plan_dft_r2c_1d(NUMR, b, B, FFTW_ESTIMATE);
-      pinv = fftw_plan_dft_c2r_1d(NUMR, C, c, FFTW_ESTIMATE);
+      pa   = fftw_plan_dft_r2c_1d(NUMR, a.data(), A.data(), FFTW_ESTIMATE);
+      pb   = fftw_plan_dft_r2c_1d(NUMR, b.data(), B.data(), FFTW_ESTIMATE);
+      pinv = fftw_plan_dft_c2r_1d(NUMR, C.data(), c.data(), FFTW_ESTIMATE);
 
       double xmin=rmin, xmax=rmax;
 
@@ -370,7 +370,7 @@ main(int argc, char **argv)
       double scale = dk / NUMR;
       int indx;
 
-      ofstream tin, tout;
+      std::ofstream tin, tout;
 
       if (myid==0) {
 	tin.open("ebar_fft.input");
@@ -414,7 +414,7 @@ main(int argc, char **argv)
       // ...
 
       double mbar=-1.0;
-      vector<double> rr(NUMR), mm(NUMR);
+      std::vector<double> rr(NUMR), mm(NUMR);
       double fac;
 
       for (int i=0; i<NUMR; i++) {

--- a/utils/PhaseSpace/pspmono.cc
+++ b/utils/PhaseSpace/pspmono.cc
@@ -185,15 +185,15 @@ main(int argc, char **argv)
 
       double val;
       static int buf_size = 1024;
-      char buf[buf_size];
+      auto buf = std::make_unique<char[]>(buf_size);
       
       std::vector<double> or_time, or_c[3];
 
       while (!in.eof()) {
-	in.getline(buf, buf_size);
+	in.getline(buf.get(), buf_size);
 	if (in.eof()) break;
 	
-	istringstream ins(buf);
+	istringstream ins(buf.get());
 	ins >> val;
 	or_time.push_back(val);
 	for (int k=0; k<5; k++) ins >> val;


### PR DESCRIPTION
**Problem**

The `pyEXP.coefs.setMatrix()` routines fail to cast `ndarray` with complex type to `Eigen::MatrixXd`.  Not all compiles demonstrated the problem.  But recent compiles in the Docker container are affected.

**Proposed fix**

Use `Eigen::Ref<Eigen::ComplexXcd>`  to pass arrays in `setMatrix()` rather than `const Eigen::MatrixXcd&`.  Tests show that this fixed the issue.

**To Do**
The implementation has been verified on the failing case but more testing is needed.