### PR TITLE
Fix potential factor issue

### DIFF
--- a/expui/BiorthBasis.cc
+++ b/expui/BiorthBasis.cc
@@ -599,7 +599,7 @@ namespace BasisClasses
        (den0 + den1) * densfac,	// 2
        pot0 * potlfac,		// 3
        pot1 * potlfac,		// 4
-       (pot0 + pot1) * densfac,	// 5
+       (pot0 + pot1) * potlfac,	// 5
        potr * (-potlfac)/scale,	// 6
        pott * (-potlfac),	// 7
        potp * (-potlfac)};	// 8


### PR DESCRIPTION
Small issue where the density scaling factor is applied to one pyEXP output instead of the potential factor.

Should check for other related issues before merging.