### PR TITLE
Clang compliance

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,8 +34,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential libeigen3-dev libfftw3-dev libhdf5-dev libopenmpi-dev libomp-dev
-          sudo pip install numpy
+          sudo apt-get install -y build-essential libeigen3-dev libfftw3-dev libhdf5-dev libopenmpi-dev libomp-dev python3-numpy
 
 
       - name: Setup submodule and build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,11 +13,16 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, ubuntu-22.04]
+        cc: [gcc, clang]
+        cxx: [g++, clang++]
         include:
+          - cxx: clang++
+            cxxflags: -stdlib=libstdc++
+        exclude:
           - cc: gcc
-            cxx: g++
-          - cc: clang
             cxx: clang++
+          - cc: clang
+            cxx: g++
 
     name: "Test pyEXP Build"
     runs-on: ${{ matrix.os }}
@@ -51,6 +56,7 @@ jobs:
           -DCMAKE_BUILD_TYPE=Release
           -DEigen3_DIR=/usr/include/eigen3/share/eigen3/cmake
           -DCMAKE_INSTALL_PREFIX=./install
+          -DCMAKE_CXX_FLAGS=${{ matrix.cxxflags }}
           -Wno-dev
           ..
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
   exp:
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-22.04]
+        os: [ubuntu-24.04, ubuntu-22.04]
         cc: [gcc, clang]
         cxx: [g++, clang++]
         include:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,6 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 # Compiler flags.  Not all tested thoroughly...
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   # using Clang
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
   # using GCC
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "Intel")

--- a/expui/BiorthBasis.cc
+++ b/expui/BiorthBasis.cc
@@ -368,7 +368,7 @@ namespace BasisClasses
   {
     // Sanity check on derived class type
     //
-    if (typeid(*coef) != typeid(CoefClasses::SphStruct))
+    if (typeid(coef.get()) != typeid(CoefClasses::SphStruct*))
       throw std::runtime_error("Spherical::set_coefs: you must pass a CoefClasses::SphStruct");
 
     // Sanity check on dimensionality
@@ -1431,7 +1431,7 @@ namespace BasisClasses
 
   void Cylindrical::set_coefs(CoefClasses::CoefStrPtr coef)
   {
-    if (typeid(*coef) != typeid(CoefClasses::CylStruct))
+    if (typeid(coef.get()) != typeid(CoefClasses::CylStruct*))
       throw std::runtime_error("Cylindrical::set_coefs: you must pass a CoefClasses::CylStruct");
 
     CoefClasses::CylStruct* cf = dynamic_cast<CoefClasses::CylStruct*>(coef.get());
@@ -1708,7 +1708,7 @@ namespace BasisClasses
   {
     // Sanity check on derived class type
     //
-    if (typeid(*coef) != typeid(CoefClasses::CylStruct))
+    if (typeid(coef.get()) != typeid(CoefClasses::CylStruct*))
       throw std::runtime_error("FlatDisk::set_coefs: you must pass a CoefClasses::CylStruct");
 
     // Sanity check on dimensionality
@@ -2140,7 +2140,7 @@ namespace BasisClasses
   {
     // Sanity check on derived class type
     //
-    if (typeid(*coef) != typeid(CoefClasses::SlabStruct))
+    if (typeid(coef) != typeid(CoefClasses::SlabStruct*))
       throw std::runtime_error("Slab::set_coefs: you must pass a CoefClasses::SlabStruct");
 
     // Sanity check on dimensionality
@@ -2572,7 +2572,7 @@ namespace BasisClasses
   {
     // Sanity check on derived class type
     //
-    if (typeid(*coef) != typeid(CoefClasses::CubeStruct))
+    if (typeid(coef.get()) != typeid(CoefClasses::CubeStruct*))
       throw std::runtime_error("Cube::set_coefs: you must pass a CoefClasses::CubeStruct");
 
     // Sanity check on dimensionality

--- a/expui/CoefContainer.cc
+++ b/expui/CoefContainer.cc
@@ -72,7 +72,7 @@ namespace MSSA
       unpack_cylfld();
     }
     else {
-      throw std::runtime_error(std::string("CoefDB::unpack_channels(): can not reflect coefficient type=") + typeid(*coefs.get()).name());
+      throw std::runtime_error(std::string("CoefDB::unpack_channels(): can not reflect coefficient type=") + typeid(coefs.get()).name());
     }
 
     return coefs;
@@ -91,7 +91,7 @@ namespace MSSA
     else if (dynamic_cast<CoefClasses::CylFldCoefs*>(coefs.get()))
       { } // Do nothing
     else {
-      throw std::runtime_error(std::string("CoefDB::background(): can not reflect coefficient type=") + typeid(*coefs.get()).name());
+      throw std::runtime_error(std::string("CoefDB::background(): can not reflect coefficient type=") + typeid(coefs.get()).name());
     }
   }
 
@@ -112,7 +112,7 @@ namespace MSSA
     else if (dynamic_cast<CoefClasses::CylFldCoefs*>(coefs.get()))
       pack_cylfld();
     else {
-      throw std::runtime_error(std::string("CoefDB::pack_channels(): can not reflect coefficient type=") + typeid(*coefs.get()).name());
+      throw std::runtime_error(std::string("CoefDB::pack_channels(): can not reflect coefficient type=") + typeid(coefs.get()).name());
     }
   }
 

--- a/exputil/BarrierWrapper.cc
+++ b/exputil/BarrierWrapper.cc
@@ -101,12 +101,13 @@ void BarrierWrapper::light_operator(const string& label,
 
 				// Compare adjacent strings in the list
     if (localid==0) {
-      char tmp[cbufsz];		// Working buffer
+				// Working buffer
+      auto tmp = std::make_unique<char[]>(cbufsz);
       bool firstime   = true;
-      string one, two = strncpy(tmp, &bufferT[0], cbufsz);
+      string one, two = strncpy(tmp.get(), &bufferT[0], cbufsz);
       for (int n=1; n<commsize; n++) {
 	one = two;
-	two = strncpy(tmp, &bufferT[cbufsz*n], cbufsz);
+	two = strncpy(tmp.get(), &bufferT[cbufsz*n], cbufsz);
 	if (one.compare(two) != 0) {
 	  if (firstime) {
 	    cout << std::string(60,'-') << std::endl << left

--- a/exputil/EmpCylSL.cc
+++ b/exputil/EmpCylSL.cc
@@ -5875,7 +5875,7 @@ void EmpCylSL::dump_images(const string& OUTFILE,
   //============
   // Open files
   //============
-  std::ofstream out[Number];
+  auto out = std::make_unique<std::ofstream[]>(Number);
   for (int j=0; j<Number; j++) {
     Name = OUTFILE + Types[j] + ".eof_recon";
     out[j].open(Name.c_str());

--- a/exputil/GaussCore.c
+++ b/exputil/GaussCore.c
@@ -26,19 +26,18 @@
 /*
    Forward declaration for function QQp:
 */
-static int QQp();
+static int QQp(double, double*, double*);
 
 /*
    Function to test a real value for exceeding -1,
    and quit on an error if condition not met.
 */
-void GaussCheck(value)
-double value;
+void GaussCheck(double value)
 {
-    if (value <= (-1.0)) {
-	fprintf(stderr, "Gauss package: parameter out of range: %g\n", value);
-	exit(1);
-    }
+  if (value <= (-1.0)) {
+    fprintf(stderr, "Gauss package: parameter out of range: %g\n", value);
+    exit(1);
+  }
 }
 
 
@@ -54,11 +53,8 @@ static int n1;
 /*
    The workhorse.
 */
-void GaussMaster(n, alpha, beta, conflag, abscis, weight)
-int n;
-double alpha, beta;
-int conflag;
-double abscis[], weight[];
+void GaussMaster(int n, double alpha, double beta, int conflag,
+		 double abscis[], double weight[])
 {
 #define FALSE 0
 #define  TRUE 1

--- a/exputil/GaussCore.h
+++ b/exputil/GaussCore.h
@@ -12,8 +12,10 @@
 #define   CONFLUENT 1
 #define NOCONFLUENT 0
 
-extern void GaussMaster();
-extern void GaussCheck();
+extern void GaussMaster(int n, double alpha, double beta, int conflag,
+			double abscis[], double weight[]);
+
+extern void GaussCheck(double value);
 
 /* ARGUMENT LISTS:
 

--- a/exputil/Hermite.c
+++ b/exputil/Hermite.c
@@ -23,9 +23,8 @@
 */
 #define odd(n) ((unsigned)(n) & 01)
 
-void Odd_Hermite(n, alpha, abscis, weight, w0)
-int n;
-double alpha, abscis[], weight[], *w0;
+void Odd_Hermite(int n, double alpha, double abscis[], double weight[],
+		 double* w0)
 {
     int k;
 
@@ -41,9 +40,7 @@ double alpha, abscis[], weight[], *w0;
 };
 
 
-void Even_Hermite(n, alpha, abscis, weight)
-int n;
-double alpha, abscis[], weight[];
+void Even_Hermite(int n, double alpha, double abscis[], double weight[])
 {
     int k;
 
@@ -59,9 +56,7 @@ double alpha, abscis[], weight[];
 };
 
 
-void Hermite(n, alpha, abscis, weight)
-int n;
-double alpha, abscis[], weight[];
+void Hermite(int n, double alpha, double abscis[], double weight[])
 {
     int n1, k;
 

--- a/exputil/Hermite.h
+++ b/exputil/Hermite.h
@@ -15,9 +15,12 @@
    Translation of module Hermite (export).
 */
 
-extern void Odd_Hermite();
-extern void Even_Hermite();
-extern void Hermite();
+extern void Odd_Hermite(int n, double alpha, double abscis[], double weight[],
+			double* w0);
+
+extern void Even_Hermite(int n, double alpha, double abscis[], double weight[]);
+
+extern void Hermite(int n, double alpha, double abscis[], double weight[]);
 
 /* ARGUMENT LISTS:
    

--- a/exputil/Jacobi.c
+++ b/exputil/Jacobi.c
@@ -20,10 +20,7 @@
 
 #define sqr(x) ((x)*(x))
 
-void Jacobi(n, alpha, beta, abscis, weight)
-int n;
-double alpha, beta;
-double abscis[], weight[];
+void Jacobi(int n, double alpha, double beta, double abscis[], double weight[])
 {
     int k;
 
@@ -34,10 +31,8 @@ double abscis[], weight[];
 }
 
 
-void Radau_Jacobi(n, alpha, beta, abscis, weight, leftw)
-int n;
-double alpha, beta;
-double abscis[], weight[], *leftw;
+void Radau_Jacobi(int n, double alpha, double beta,
+		  double abscis[], double weight[], double *leftw)
 {
     int k;
     double temp;
@@ -62,10 +57,9 @@ double abscis[], weight[], *leftw;
 };
 
 
-void Lobatto_Jacobi(n, alpha, beta, abscis, weight, leftw, rightw)
-int n;
-double alpha, beta;
-double abscis[], weight[], *leftw, *rightw;
+void Lobatto_Jacobi(int n, double alpha, double beta,
+		    double abscis[], double weight[],
+		    double* leftw, double* rightw)
 {
     int k;
     double temp1, temp2;

--- a/exputil/Jacobi.h
+++ b/exputil/Jacobi.h
@@ -15,10 +15,15 @@
    Translation of module Jacobi (export).
 */
 
+extern void Jacobi(int n, double alpha, double beta,
+		   double abscis[], double weight[]);
 
-extern void Jacobi();
-extern void Radau_Jacobi();
-extern void Lobatto_Jacobi();
+extern void Radau_Jacobi(int n, double alpha, double beta,
+			 double abscis[], double weight[], double *leftw);
+
+extern void Lobatto_Jacobi(int n, double alpha, double beta,
+			   double abscis[], double weight[],
+			   double* leftw, double* rightw);
 
 /* ARGUMENT LISTS:
    void Jacobi(n, alpha, beta, abscis, weight)

--- a/exputil/Laguerre.c
+++ b/exputil/Laguerre.c
@@ -15,18 +15,15 @@
 #include "GaussCore.h"
 #include "Laguerre.h"
 
-void Laguerre(n, alpha, abscis, weight)
-int n;
-double alpha, abscis[], weight[];
+void Laguerre(int n, double alpha, double abscis[], double weight[])
 {
     GaussCheck(alpha);
     GaussMaster(n, alpha, 0.0, CONFLUENT, abscis, weight);
 };
 
 
-void Radau_Laguerre(n, alpha, abscis, weight, leftw)
-int n;
-double alpha, abscis[], weight[], *leftw;
+void Radau_Laguerre(int n, double alpha, double abscis[], double weight[],
+		    double* leftw)
 {
     int k;
     double temp;

--- a/exputil/Laguerre.h
+++ b/exputil/Laguerre.h
@@ -15,8 +15,10 @@
    Translation of module Laguerre (export).
 */
 
-extern void Laguerre();
-extern void Radau_Laguerre();
+extern void Laguerre(int n, double alpha, double abscis[], double weight[]);
+
+extern void Radau_Laguerre(int n, double alpha,
+			   double abscis[], double weight[], double* leftw);
 
 /* 
    ARGUMENT LISTS:

--- a/exputil/ParticleReader.cc
+++ b/exputil/ParticleReader.cc
@@ -3,6 +3,7 @@
 #include <iomanip>
 #include <fstream>
 #include <sstream>
+#include <memory>
 #include <numeric>
 #include <string>
 #include <vector>
@@ -530,11 +531,11 @@ namespace PR {
 	    
 	    int rank = dataspace.getSimpleExtentNdims();
 	    
-	    hsize_t dims[rank];
+	    auto dims = std::make_unique<hsize_t[]>(rank);
 	    
-	    int ndims = dataspace.getSimpleExtentDims(dims, NULL);
+	    int ndims = dataspace.getSimpleExtentDims(dims.get(), NULL);
 	    
-	    H5::DataSpace mspace(rank, dims);
+	    H5::DataSpace mspace(rank, dims.get());
 	    
 	    std::vector<float> masses(dims[0]);
 	    dataset.read(&masses[0], H5::PredType::NATIVE_FLOAT, mspace, dataspace );
@@ -569,11 +570,11 @@ namespace PR {
 	  
 	  int rank = dataspace.getSimpleExtentNdims();
 	  
-	  hsize_t dims[rank];
+	  auto dims = std::make_unique<hsize_t[]>(rank);
 	  
-	  int ndims = dataspace.getSimpleExtentDims( dims, NULL);
+	  int ndims = dataspace.getSimpleExtentDims( dims.get(), NULL);
 	  
-	  H5::DataSpace mspace(rank, dims);
+	  H5::DataSpace mspace(rank, dims.get());
 	  
 	  std::vector<unsigned> seq(dims[0]);
 	  dataset.read(&seq[0], H5::PredType::NATIVE_UINT32, mspace, dataspace );

--- a/exputil/YamlConfig.cc
+++ b/exputil/YamlConfig.cc
@@ -71,7 +71,7 @@ cxxopts::ParseResult LoadConfig(cxxopts::Options& options,
   YAML::Node conf = YAML::LoadFile(config);
 
   int count = conf.size()*2+1, cnt = 1;
-  char* data[count];
+  std::vector<char*> data(count);
 
   data[0] = new char [11];
   strcpy(data[0], "LoadConfig"); // Emulate the caller name

--- a/include/DiskWithHalo.H
+++ b/include/DiskWithHalo.H
@@ -66,13 +66,13 @@ public:
     dur = dur1 + dur2;
   }
   
-  double get_mass(const double x1, const double x2, const double x3)
+  double get_mass(const double x1, const double x2, const double x3) override
   { return get_mass(sqrt(x1*x1 + x2*x2 + x3*x3)); }
   
-  double get_density(const double x1, const double x2, const double x3)
+  double get_density(const double x1, const double x2, const double x3) override
   { return get_density(sqrt(x1*x1 + x2*x2 + x3*x3)); }
   
-  double get_pot(const double x1, const double x2, const double x3)
+  double get_pot(const double x1, const double x2, const double x3) override
   { return get_pot(sqrt(x1*x1 + x2*x2 + x3*x3)); }
 
   // Addiional member functions

--- a/include/EXPini.H
+++ b/include/EXPini.H
@@ -87,8 +87,9 @@ cxxopts::ParseResult LoadConfig(cxxopts::Options& options,
 {
   YAML::Node conf = YAML::LoadFile(config);
 
-  int count = conf.size()*2+1, cnt = 1;
+  const int count = conf.size()*2+1;
   char* data[count];
+  int cnt = 1;
 
   data[0] = new char [11];
   strcpy(data[0], "LoadConfig"); // Emulate the caller name

--- a/include/EXPini.H
+++ b/include/EXPini.H
@@ -88,7 +88,7 @@ cxxopts::ParseResult LoadConfig(cxxopts::Options& options,
   YAML::Node conf = YAML::LoadFile(config);
 
   const int count = conf.size()*2+1;
-  char* data[count];
+  std::vector<char*> data(count);
   int cnt = 1;
 
   data[0] = new char [11];
@@ -131,7 +131,7 @@ cxxopts::ParseResult LoadConfig(cxxopts::Options& options,
   
   auto vm = options.parse(cnt, &data[0]);
 
-  for (int i=0; i<cnt; i++) delete [] data[i];
+  for (auto & v : data) delete [] v;
 
   return vm;
 }

--- a/include/SLGridMP2.H
+++ b/include/SLGridMP2.H
@@ -314,6 +314,9 @@ private:
     //! Constructor
     CoordMap(double H) : H(H) {}
   
+    //! Destructor
+    virtual ~CoordMap() {}
+
     //! Convert from vertical to mapped coordinate
     virtual double z_to_xi  (double z) = 0;
 

--- a/include/TransformFFT.H
+++ b/include/TransformFFT.H
@@ -2,11 +2,12 @@
 #ifndef _TransformFFT_h
 #define _TransformFFT_h
 
+#include <complex>
+#include <vector>
+
 #include <Eigen/Dense>
 #include <fftw3.h>
 
-#include <complex>
-#include <vector>
 
 class TransformFFT
 {
@@ -15,7 +16,7 @@ class TransformFFT
 
   fftw_plan p;
   std::vector<double> in;
-  fftw_complex* out;
+  std::vector<std::complex<double>> out;
 
  public:
   

--- a/include/massmodel.H
+++ b/include/massmodel.H
@@ -188,13 +188,13 @@ public:
   virtual double get_dpot2(const double) = 0;
   virtual void get_pot_dpot(const double, double&, double&) = 0;
   
-  double get_mass(const double x1, const double x2, const double x3)
+  double get_mass(const double x1, const double x2, const double x3) override
   { return get_mass(sqrt(x1*x1 + x2*x2 + x3*x3)); }
   
-  double get_density(const double x1, const double x2, const double x3)
+  double get_density(const double x1, const double x2, const double x3) override
   { return get_density(sqrt(x1*x1 + x2*x2 + x3*x3)); }
   
-  double get_pot(const double x1, const double x2, const double x3)
+  double get_pot(const double x1, const double x2, const double x3) override
   { return get_pot(sqrt(x1*x1 + x2*x2 + x3*x3)); }
   //@}
   

--- a/utils/Analysis/gas2dcyl.cc
+++ b/utils/Analysis/gas2dcyl.cc
@@ -171,9 +171,9 @@ main(int argc, char **argv)
       char *c = const_cast<char*>(files[n].c_str());
       MPI_Bcast(c, sz+1, MPI_CHAR, 0, MPI_COMM_WORLD);
     } else {
-      char l[sz+1];
-      MPI_Bcast(&l[0], sz+1, MPI_CHAR, 0, MPI_COMM_WORLD);
-      files.push_back(l);
+      auto l = std::make_unique<char[]>(sz+1);
+      MPI_Bcast(l.get(), sz+1, MPI_CHAR, 0, MPI_COMM_WORLD);
+      files.push_back(l.get());
     }
     MPI_Barrier(MPI_COMM_WORLD);
   }

--- a/utils/Analysis/psphisto.cc
+++ b/utils/Analysis/psphisto.cc
@@ -34,8 +34,9 @@
 #include <iomanip>
 #include <fstream>
 #include <sstream>
-#include <cmath>
+#include <memory>
 #include <string>
+#include <cmath>
 
                                 // System libs
 #include <sys/time.h>
@@ -177,9 +178,9 @@ main(int argc, char **argv)
       char *c = const_cast<char*>(files[n].c_str());
       MPI_Bcast(c, sz+1, MPI_CHAR, 0, MPI_COMM_WORLD);
     } else {
-      char l[sz+1];
-      MPI_Bcast(&l[0], sz+1, MPI_CHAR, 0, MPI_COMM_WORLD);
-      files.push_back(l);
+      auto l = std::make_unique<char[]>(sz+1);
+      MPI_Bcast(l.get(), sz+1, MPI_CHAR, 0, MPI_COMM_WORLD);
+      files.push_back(l.get());
     }
     MPI_Barrier(MPI_COMM_WORLD);
   }

--- a/utils/ICs/SphericalSL.cc
+++ b/utils/ICs/SphericalSL.cc
@@ -245,7 +245,7 @@ void SphericalSL::compute_coefficients_single(vector<Particle> &part)
 
 void SphericalSL::compute_coefficients_thread(vector<Particle>& part)
 {
-  std::thread t[nthrds];
+  std::vector<std::thread> t(nthrds);
  
   // Launch the threads
   for (int id=0; id<nthrds; ++id) {

--- a/utils/ICs/gensph.cc
+++ b/utils/ICs/gensph.cc
@@ -355,13 +355,13 @@ main(int argc, char **argv)
 #ifdef HAVE_FFTW
     if (SMOOTH>0.0) {
 
-      double a[NUMR], b[NUMR], c[NUMR];
-      fftw_complex A[NUMR], B[NUMR], C[NUMR];
+      std::vector<double> a(NUMR), b(NUMR), c(NUMR);
+      std::vector<fftw_complex> A(NUMR), B(NUMR), C(NUMR);
       fftw_plan pa, pb, pinv;
 
-      pa   = fftw_plan_dft_r2c_1d(NUMR, a, A, FFTW_ESTIMATE);
-      pb   = fftw_plan_dft_r2c_1d(NUMR, b, B, FFTW_ESTIMATE);
-      pinv = fftw_plan_dft_c2r_1d(NUMR, C, c, FFTW_ESTIMATE);
+      pa   = fftw_plan_dft_r2c_1d(NUMR, a.data(), A.data(), FFTW_ESTIMATE);
+      pb   = fftw_plan_dft_r2c_1d(NUMR, b.data(), B.data(), FFTW_ESTIMATE);
+      pinv = fftw_plan_dft_c2r_1d(NUMR, C.data(), c.data(), FFTW_ESTIMATE);
 
       double xmin=rmin, xmax=rmax;
 
@@ -370,7 +370,7 @@ main(int argc, char **argv)
       double scale = dk / NUMR;
       int indx;
 
-      ofstream tin, tout;
+      std::ofstream tin, tout;
 
       if (myid==0) {
 	tin.open("ebar_fft.input");
@@ -414,7 +414,7 @@ main(int argc, char **argv)
       // ...
 
       double mbar=-1.0;
-      vector<double> rr(NUMR), mm(NUMR);
+      std::vector<double> rr(NUMR), mm(NUMR);
       double fac;
 
       for (int i=0; i<NUMR; i++) {

--- a/utils/PhaseSpace/pspmono.cc
+++ b/utils/PhaseSpace/pspmono.cc
@@ -185,15 +185,15 @@ main(int argc, char **argv)
 
       double val;
       static int buf_size = 1024;
-      char buf[buf_size];
+      auto buf = std::make_unique<char[]>(buf_size);
       
       std::vector<double> or_time, or_c[3];
 
       while (!in.eof()) {
-	in.getline(buf, buf_size);
+	in.getline(buf.get(), buf_size);
 	if (in.eof()) break;
 	
-	istringstream ins(buf);
+	istringstream ins(buf.get());
 	ins >> val;
 	or_time.push_back(val);
 	for (int k=0; k<5; k++) ins >> val;


### PR DESCRIPTION
**Summary**
This addresses all the warnings generated by `clang++` from PR #85 and includes that PR.  

There are three types of fixes:
1.  Remove arrays with non-constant dimensions at compile time.  These are fixed in one of two ways: either a `std::vector<T>` or a `std::unique_ptr<T[]>` to automatically manage memory.
2. Dereferencing a `std::shared_ptr` to do a dynamic cast for a type was flagged by the compiler as "expressions with side-effects", even though I think they are probably okay .  These were switched to dynamic casts to pointers to types, with no "side effects".  
3. Fixed a bunch of C-code headers without proper signatures.

The compiled code passes `ctest -L long` tests.  Several of these changes are in `expui` code.  While I do not think that the likelihood of breaking code is low (since most of these changes are in memory management for buffers), I might be good to check this code against the `pyEXP-examples/Tutorials` notebooks for verification.