### PR TITLE
Incorrect machine constant checks for Legendre recursion relations

### DIFF
--- a/src/Basis.cc
+++ b/src/Basis.cc
@@ -4,7 +4,7 @@
 
 // Machine constant for Legendre
 //
-constexpr double MINEPS = 20.0*std::numeric_limits<double>::min();
+constexpr double MINEPS = 3.0*std::numeric_limits<double>::epsilon();
 
 Basis::Basis(Component* c0, const YAML::Node& conf) : PotAccel(c0, conf)
 {


### PR DESCRIPTION
## Summary

Previous version of the code used the minimum floating number not the minimum `epsilon`  such that `1+epsilon != 1`, which it should have used.

## Fix

Use additive machine constants from C++ `limits` to set epsilon in Legendre functions on CPU and GPU.  The assumption here is that both are use IEEE 754 standard for FP arithmetic.  On the GPU side, the constant is set to float or double based on the value of `cuREAL` in `cudaUtil.cuH`.

## Details

The gaff was discovered in positional quiet starts that happened to have `|cos(\theta)| = 1`.   This resulted in `inf` for Legendre function derivatives owing to divide by zero rather than cancellation.  This has been rechecked with the fix enabled on the same previously failing ICs.