### PR TITLE
Updates to IC generation routines in `utils/ICs`

### DIFF
--- a/exputil/EXPmath.cc
+++ b/exputil/EXPmath.cc
@@ -61,12 +61,12 @@ namespace AltMath
     return ans;
   }
 
-#define ACC 40.0
-#define BIGNO 1.0e10
-#define BIGNI 1.0e-10
-
   double bessj(int n,double x)
   {
+    const double ACC = 40.0;
+    const double BIGNO = 1.0e10;
+    const double BIGNI = 1.0e-10;
+
     int j,jsum,m;
     double ax,bj,bjm,bjp,sum,tox,ans;
     
@@ -114,10 +114,6 @@ namespace AltMath
     return  x < 0.0 && n%2 == 1 ? -ans : ans;
   }
   
-#undef ACC
-#undef BIGNO
-#undef BIGNI
-
   double bessk0(double x)
   {
     double y,ans;
@@ -174,12 +170,12 @@ namespace AltMath
     return ans;
   }
 
-#define ACC 40.0
-#define BIGNO 1.0e10
-#define BIGNI 1.0e-10
-
   double bessi(int n,double x)
   {
+    const double ACC = 40.0;
+    const double BIGNO = 1.0e10;
+    const double BIGNI = 1.0e-10;
+
     int j;
     double bi,bim,bip,tox,ans;
     double bessi0(double );
@@ -206,10 +202,6 @@ namespace AltMath
       return  x < 0.0 && n%2 == 1 ? -ans : ans;
     }
   }
-
-#undef ACC
-#undef BIGNO
-#undef BIGNI
 
   double bessi0(double x)
   {
@@ -253,12 +245,12 @@ namespace AltMath
     return x < 0.0 ? -ans : ans;
   }
 
-#define ACC 40.0
-#define BIGNO 1.0e10
-#define BIGNI 1.0e-10
-
   double jn_sph(int n, double x)
   {
+    const double ACC = 40.0;
+    const double BIGNO = 1.0e10;
+    const double BIGNI = 1.0e-10;
+
     int j,m;
     double ax,bj,bjm,bjp,tox,ans;
     double jn_sph0(double x),jn_sph1(double x),jn_sphm1(double x);
@@ -306,13 +298,10 @@ namespace AltMath
     return  x < 0.0 && n%2 == 1 ? -ans : ans;
   }
   
-#undef ACC
-#undef BIGNO
-#undef BIGNI
-
-#define TOL 1.0e-7
   double jn_sph0(double x)
   {
+    const double TOL = 1.0e-7;
+
     if (fabs(x)<TOL)
       return 1.0-x*x/6.0;
     else
@@ -321,6 +310,8 @@ namespace AltMath
 
   double jn_sph1(double x)
   {
+    const double TOL = 1.0e-7;
+
     if (fabs(x)<TOL)
       return x/3.0;
     else
@@ -331,7 +322,6 @@ namespace AltMath
   {
     return cos(x)/x;
   }
-#undef TOL
 
   double check_nu(double nu)
   {

--- a/exputil/EmpCyl2d.cc
+++ b/exputil/EmpCyl2d.cc
@@ -815,8 +815,8 @@ bool EmpCyl2d::ReadH5Cache()
       if (not checkStr(Version, "Version"))  return false;
     } else {
       if (myid==0)
-	std::cout << "---- EmpCyl2d::ReadH5Cache: "
-		  << "recomputing cache for HighFive API change"
+	std::cout << "---- EmpCyl2d::ReadH5Cache: " << "<" << cache_name_2d
+		  << "> recomputing cache for HighFive API change"
 		  << std::endl;
       return false;
     }

--- a/exputil/EmpCyl2d.cc
+++ b/exputil/EmpCyl2d.cc
@@ -780,19 +780,31 @@ bool EmpCyl2d::ReadH5Cache()
     auto checkInt = [&file](int value, std::string name)
     {
       int v; HighFive::Attribute vv = file.getAttribute(name); vv.read(v);
-      if (value == v) return true; return false;
+      if (value == v) return true;
+      if (myid==0) std::cout << "---- EmpCyl2d::ReadH5Cache: "
+			     << name << " expected " << value << " but found "
+			     << v << std::endl;
+      return false;
     };
 
     auto checkDbl = [&file](double value, std::string name)
     {
       double v; HighFive::Attribute vv = file.getAttribute(name); vv.read(v);
-      if (fabs(value - v) < 1.0e-16) return true; return false;
+      if (fabs(value - v) < 1.0e-16) return true;
+      if (myid==0) std::cout << "---- EmpCyl2d::ReadH5Cache: "
+			     << name << " expected " << value << " but found "
+			     << v << std::endl;
+      return false;
     };
 
     auto checkStr = [&file](std::string value, std::string name)
     {
       std::string v; HighFive::Attribute vv = file.getAttribute(name); vv.read(v);
-      if (value.compare(v)==0) return true; return false;
+      if (value.compare(v)==0) return true;
+      if (myid==0) std::cout << "---- EmpCyl2d::ReadH5Cache: "
+			     << name << " expected " << value << " but found "
+			     << v << std::endl;
+      return false;
     };
 
     //

--- a/exputil/massmodel_dist.cc
+++ b/exputil/massmodel_dist.cc
@@ -49,14 +49,14 @@
 #include <massmodel.H>
 #include <interp.H>
 
-#define OFFSET 1.0e-3
-#define OFFTOL 1.2
+const double OFFSET=1.0e-3;
+const double OFFTOL=1.2;
 
 extern double gint_0(double a, double b, std::function<double(double)> f, int NGauss);
 extern double gint_2(double a, double b, std::function<double(double)> f, int NGauss);
 
-#define TSTEP 1.0e-8
-#define NGauss 96
+const double TSTEP=1.0e-8;
+const int    NGauss=96;
 
 static int DIVERGE=0;
 
@@ -109,6 +109,10 @@ void SphericalModelTable::setup_df(int NUM, double RA)
   rhoQy.resize(num);
   rhoQy2.resize(num);
 
+  rhoQx. setZero();
+  rhoQy. setZero();
+  rhoQy2.setZero();
+
   for (int i=0; i<num; i++) {
     x = density.x[i];
     rhoQx[i] = pot.y[i];
@@ -138,6 +142,11 @@ void SphericalModelTable::setup_df(int NUM, double RA)
     dfc.Q  .resize(NUM);
     dfc.fQ .resize(NUM);
     dfc.ffQ.resize(NUM);
+
+    dfc.Q  .setZero();
+    dfc.fQ .setZero();
+    dfc.ffQ.setZero();
+
     dfc.num = NUM;
     dfc.ra2 = ra2;
 
@@ -145,7 +154,8 @@ void SphericalModelTable::setup_df(int NUM, double RA)
     Qmin = get_pot(pot.x[0]);
     dQ = (Qmax - Qmin)/(double)(dfc.num-1);
   
-    foffset = -std::numeric_limits<double>::max();
+    // foffset = -std::numeric_limits<double>::max();
+    foffset = -1.0e42;
     dfc.Q[dfc.num-1] = Qmax;
     dfc.ffQ[dfc.num-1] = 0.0;
     fac = 1.0/(sqrt(8.0)*M_PI*M_PI);
@@ -184,6 +194,13 @@ void SphericalModelTable::setup_df(int NUM, double RA)
     df.ffQ .resize(NUM);
     df.fQ2 .resize(NUM);
     df.ffQ2.resize(NUM);
+
+    df.Q   .setZero();
+    df.fQ  .setZero();
+    df.ffQ .setZero();
+    df.fQ2 .setZero();
+    df.ffQ2.setZero();
+
     df.num = NUM;
     df.ra2 = ra2;
 
@@ -194,7 +211,8 @@ void SphericalModelTable::setup_df(int NUM, double RA)
     df.Q[df.num-1] = Qmax;
     df.ffQ[df.num-1] = 0.0;
     fac = 1.0/(sqrt(8.0)*M_PI*M_PI);
-    foffset = -std::numeric_limits<double>::max();
+    // foffset = -std::numeric_limits<double>::max();
+    foffset = -1.0e42;
     for (int i=df.num-2; i>=0; i--) {
       df.Q[i] = df.Q[i+1] - dQ;
       Q = df.Q[i];
@@ -233,7 +251,7 @@ void SphericalModelTable::setup_df(int NUM, double RA)
 
   dist_defined = true;
 
-  debug_fdist();
+  // debug_fdist();
 }
 
 
@@ -294,7 +312,7 @@ double SphericalModelTable::distf(double E, double L)
 
   if (!dist_defined) bomb("distribution function not defined");
 
-  double d, g;
+  double d=0.0, g=0.0;
 
   if (chebyN) {
 
@@ -341,7 +359,7 @@ double SphericalModelTable::dfde(double E, double L)
 
   if (!dist_defined) bomb("distribution function not defined");
 
-  double d, g, h, d1;
+  double d=0, g=0, h=0, d1=0;
 
   if (chebyN) {
     
@@ -399,7 +417,7 @@ double SphericalModelTable::dfdl(double E, double L)
 
   if (!dist_defined) bomb("distribution function not defined");
 
-  double d, g, h, d1;
+  double d=0, g=0, h=0, d1=0;
 
   if (chebyN) {
     
@@ -451,7 +469,7 @@ double SphericalModelTable::d2fde2(double E, double L)
 {
   if (!dist_defined) bomb("distribution function not defined");
 
-  double d, g, h, k, d2;
+  double d=0, g=0, h=0, k=0, d2=0;
 
   if (chebyN) {
 

--- a/exputil/realize_model.cc
+++ b/exputil/realize_model.cc
@@ -655,10 +655,11 @@ AxiSymModel::PSret AxiSymModel::gen_point_3d(double r, double theta, double phi)
   for (it=0; it<gen_itmax; it++) {
 
     double xxx = pow(Unit(random_gen), 0.3333333333333333);
-    double yyy = 0.5*M_PI*Unit(random_gen);
+    double cosq = 2.0*Unit(random_gen)-1.0;
+    double sinq = sqrt(fabs(1.0 - cosq*cosq));
 
-    vr = vmax*xxx*cos(yyy);
-    vt = vmax*xxx*sin(yyy);
+    vr = vmax*xxx*cosq;
+    vt = vmax*xxx*sinq;
     eee = pot + 0.5*(vr*vr + vt*vt);
 
     if (Unit(random_gen) > distf(eee, r*vt)/fmax ) continue;

--- a/exputil/realize_model.cc
+++ b/exputil/realize_model.cc
@@ -69,12 +69,10 @@ int      AxiSymModel::gen_itmax = 20000;
 const bool verbose = true;
 const double ftol = 0.01;
 
-Eigen::VectorXd AxiSymModel::gen_point_2d(int& ierr)
+AxiSymModel::PSret AxiSymModel::gen_point_2d()
 {
   if (!dist_defined) {
-    std::cerr << "AxiSymModel: must define distribution before realizing!"
-	      << std::endl;
-    exit (-1);
+    throw std::runtime_error("AxiSymModel: must define distribution before realizing!");
   }
 
   int it;			// Iteration counter
@@ -87,7 +85,6 @@ Eigen::VectorXd AxiSymModel::gen_point_2d(int& ierr)
   double Emin = get_pot(rmin);
   double Emax = get_pot(get_max_radius());
 
-
   if (gen_EJ) {
 
     if (gen_firstime) {
@@ -97,8 +94,9 @@ Eigen::VectorXd AxiSymModel::gen_point_2d(int& ierr)
       double dx = (Emax - Emin - 2.0*tol)/(numr-1);
       double dy = (1.0 - gen_kmin - 2.0*tol)/(numj-1);
 
+#ifdef DEBUG
       std::cout << "gen_point_2d[" << ModelID << "]: " << get_max_radius() << std::endl;
-      
+#endif
       gen_fomax = 0.0;
 
       for (int j=0; j<numr; j++) {
@@ -119,8 +117,8 @@ Eigen::VectorXd AxiSymModel::gen_point_2d(int& ierr)
     }
 
     
-				// Trial velocity point
-    
+    // Trial velocity point
+    //
     for (it=0; it<gen_itmax; it++) {
 
       double xxx = Emin + tol + (Emax - Emin - 2.0*tol)*Unit(random_gen);
@@ -166,7 +164,9 @@ Eigen::VectorXd AxiSymModel::gen_point_2d(int& ierr)
       gen_rloc.resize(gen_N);
       gen_fmax.resize(gen_N);
 
+#ifdef DEBUG
       std::cout << "gen_point_2d[" << ModelID << "]: " << get_max_radius() << std::endl;
+#endif
 
       if (rmin <= 1.0e-16) gen_logr = 0;
 
@@ -219,8 +219,8 @@ Eigen::VectorXd AxiSymModel::gen_point_2d(int& ierr)
     pot = get_pot(r);
     vmax = sqrt(2.0*fabs(Emax - pot));
 
-                                // Trial velocity point
-    
+    // Trial velocity point
+    //
     for (it=0; it<gen_itmax; it++) {
 
       double xxx = sqrt(Unit(random_gen));
@@ -254,13 +254,10 @@ Eigen::VectorXd AxiSymModel::gen_point_2d(int& ierr)
 		<< std::setw(12) << fmax
 		<< " %=" << std::setw(12)
 		<< static_cast<double>(++toomany)/totcnt << std::endl;
-    ierr = 1;
     out.setZero();
-    return out;
+    return {out, 1};
   }
 
-  ierr = 0;
-  
   cosp = cos(phi);
   sinp = sin(phi);
 
@@ -272,16 +269,14 @@ Eigen::VectorXd AxiSymModel::gen_point_2d(int& ierr)
   out[5] = vr * sinp + vt * cosp;
   out[6] = 0.0;
     
-  return out;
+  return {out, 0};
 }
 
 
-Eigen::VectorXd AxiSymModel::gen_point_2d(double r, int& ierr)
+AxiSymModel::PSret AxiSymModel::gen_point_2d(double r)
 {
   if (!dist_defined) {
-    std::cerr << "AxiSymModel: must define distribution before realizing!"
-	      << std::endl;
-    exit (-1);
+    throw std::runtime_error("AxiSymModel: must define distribution before realizing!");
   }
 
   int it;			// Iteration counter
@@ -300,8 +295,10 @@ Eigen::VectorXd AxiSymModel::gen_point_2d(double r, int& ierr)
     gen_rloc.resize(gen_N);
     gen_fmax.resize(gen_N);
 
+#ifdef DEBUG
     std::cout << "gen_point_2d[" << ModelID << "]: " << rmin
 	 << ", " << get_max_radius() << std::endl;
+#endif
 
     double dr = (get_max_radius() - rmin)/gen_N;
 
@@ -337,8 +334,8 @@ Eigen::VectorXd AxiSymModel::gen_point_2d(double r, int& ierr)
   pot = get_pot(r);
   vmax = sqrt(2.0*fabs(Emax - pot));
   
-                                // Trial velocity point
-    
+  // Trial velocity point
+  //
   for (it=0; it<gen_itmax; it++) {
 
     double xxx = sqrt(Unit(random_gen));
@@ -370,13 +367,10 @@ Eigen::VectorXd AxiSymModel::gen_point_2d(double r, int& ierr)
 		<< std::setw(12) << fmax
 		<< " %=" << std::setw(12)
 		<< static_cast<double>(++toomany)/totcnt << std::endl;
-    ierr = 1;
     out.setZero();
-    return out;
+    return {out, 1};
   }
 
-  ierr = 0;
-  
   cosp = cos(phi);
   sinp = sin(phi);
 
@@ -388,16 +382,14 @@ Eigen::VectorXd AxiSymModel::gen_point_2d(double r, int& ierr)
   out[5] = vr * sinp + vt * cosp;
   out[6] = 0.0;
     
-  return out;
+  return {out, 0};
 }
 
 
-Eigen::VectorXd AxiSymModel::gen_point_3d(int& ierr)
+AxiSymModel::PSret AxiSymModel::gen_point_3d()
 {
   if (!dist_defined) {
-    std::cerr << "AxiSymModel: must define distribution before realizing!"
-	      << std::endl;
-    exit (-1);
+    throw std::runtime_error("AxiSymModel: must define distribution before realizing!");
   }
 
 #ifdef DEBUG
@@ -405,7 +397,7 @@ Eigen::VectorXd AxiSymModel::gen_point_3d(int& ierr)
 #endif
 
   double r, pot, vmax, vr=0.0, vt, eee, vt1=0.0, vt2=0.0, fmax;
-  double phi, sint, cost, sinp, cosp, azi;
+  double phi, sint, cost, sinp, cosp;
 
   double rmin = max<double>(get_min_radius(), gen_rmin);
   double Emax = get_pot(get_max_radius());
@@ -525,7 +517,9 @@ Eigen::VectorXd AxiSymModel::gen_point_3d(int& ierr)
 
     if (Unit(random_gen)<0.5) vr *= -1.0;
     
-    azi = 2.0*M_PI*Unit(random_gen);
+    // Orientation of tangential velocity vector
+    //
+    double azi = 2.0*M_PI*Unit(random_gen);
     vt1 = vt*cos(azi);
     vt2 = vt*sin(azi);
 
@@ -544,13 +538,10 @@ Eigen::VectorXd AxiSymModel::gen_point_3d(int& ierr)
 		<< std::setw(12) << fmax
 		<< " %=" << std::setw(12)
 		<< static_cast<double>(++toomany)/totcnt << std::endl;
-    ierr = 1;
     out.setZero();
-    return out;
+    return {out, 1};
   }
 
-  ierr = 0;
-  
   if (Unit(random_gen)>=0.5) vr *= -1.0;
 
   phi = 2.0*M_PI*Unit(random_gen);
@@ -583,17 +574,139 @@ Eigen::VectorXd AxiSymModel::gen_point_3d(int& ierr)
 #endif
 
 
-  return out;
+  return {out, 0};
 }
 
 
-Eigen::VectorXd AxiSymModel::gen_point_3d(double Emin, double Emax, 
-					  double Kmin, double Kmax, int& ierr)
+AxiSymModel::PSret AxiSymModel::gen_point_3d(double r, double theta, double phi)
 {
   if (!dist_defined) {
-    std::cerr << "AxiSymModel: must define distribution before realizing!"
-	      << std::endl;
-    exit (-1);
+    throw std::runtime_error("AxiSymModel: must define distribution before realizing!");
+  }
+
+  int it;			// Iteration counter
+  double pot, vmax, vr=0.0, vt=0.0, eee, fmax;
+  double rmin = max<double>(get_min_radius(), gen_rmin);
+  double Emax = get_pot(get_max_radius());
+
+  if (gen_firstime) {
+
+    double tol = 1.0e-5;
+    double dx = (1.0 - 2.0*tol)/(numr-1);
+    double dy = (1.0 - 2.0*tol)/(numj-1);
+
+    gen_mass.resize(gen_N);
+    gen_rloc.resize(gen_N);
+    gen_fmax.resize(gen_N);
+
+#ifdef DEBUG
+    std::cout << "gen_point_3d[" << ModelID << "]: " << rmin
+	 << ", " << get_max_radius() << std::endl;
+#endif
+
+    double dr = (get_max_radius() - rmin)/gen_N;
+
+    for (int i=0; i<gen_N; i++) {
+      gen_rloc[i] = rmin + dr*i;
+      gen_mass[i] = get_mass(gen_rloc[i]);
+
+      pot = get_pot(gen_rloc[i]);
+      vmax = sqrt(2.0*fabs(Emax - pot));
+
+      fmax = 0.0;
+      for (int j=0; j<numr; j++) {
+	double xxx = sqrt(tol + dx*j);
+
+	for (int k=0; k<numj; k++) {
+	  double yyy = 0.5*M_PI*(tol + dy*k);
+
+	  vr = vmax*xxx*cos(yyy);
+	  vt = vmax*xxx*sin(yyy);
+	  eee = pot + 0.5*(vr*vr + vt*vt);
+
+	  double zzz = distf(eee, gen_rloc[i]*vt);
+	  fmax = zzz>fmax ? zzz : fmax;
+	}
+      }
+      gen_fmax[i] = fmax*(1.0 + ftol);
+
+    }
+    gen_firstime = false;
+  }
+
+  fmax = odd2(r, gen_rloc, gen_fmax, 1);
+  pot  = get_pot(r);
+  vmax = sqrt(2.0*fabs(Emax - pot));
+  
+  // Trial velocity point
+  //
+  for (it=0; it<gen_itmax; it++) {
+
+    double xxx = pow(Unit(random_gen), 0.3333333333333333);
+    double yyy = 0.5*M_PI*Unit(random_gen);
+
+    vr = vmax*xxx*cos(yyy);
+    vt = vmax*xxx*sin(yyy);
+    eee = pot + 0.5*(vr*vr + vt*vt);
+
+    if (Unit(random_gen) > distf(eee, r*vt)/fmax ) continue;
+    
+    if (Unit(random_gen)<0.5) vr *= -1.0;
+    
+    break;
+  }
+
+  Eigen::VectorXd out(7);
+
+  if (std::isnan(vr) or std::isnan(vt)) {
+    if (verbose) std::cout << "NaN found in AxiSymModel::gen_point_3d with r="
+			   << r << " theta=" << theta << " phi=" << phi
+			   << std::endl;
+    out.setZero();
+    return {out, 1};
+  }
+  
+  static unsigned totcnt = 0, toomany = 0;
+  totcnt++;
+
+  if (it==gen_itmax) {
+    if (verbose)
+      std::cerr << "Velocity selection failed [" << myid << "]: r="
+		<< std::setw(12) << r
+		<< std::setw(12) << fmax
+		<< " %=" << std::setw(12)
+		<< static_cast<double>(++toomany)/totcnt << std::endl;
+    out.setZero();
+    return {out, 1};
+  }
+
+  double tv  = 2.0*M_PI*Unit(random_gen);
+  double vth = vt*cos(tv);
+  double vph = vt*sin(tv);
+
+  double cost = cos(theta);
+  double sint = sin(theta);
+
+  double cosp = cos(phi);
+  double sinp = sin(phi);
+
+  out[0] = 1.0;
+  out[1] = r*sint*cosp;
+  out[2] = r*sint*sinp;
+  out[3] = r*cost;
+  out[4] = vr*sint*cosp - vph*sinp + vth*cost*cosp;
+  out[5] = vr*sint*sinp + vph*cosp + vth*cost*sinp;
+  out[6] = vr*cost - vth*sint;
+    
+  return {out, 0};
+}
+
+
+AxiSymModel::PSret AxiSymModel::gen_point_3d(double Emin, double Emax, 
+				double Kmin, double Kmax)
+{
+  if (!dist_defined) {
+    throw std::runtime_error("AxiSymModel: must define distribution before realizing!");
   }
 
 #ifdef DEBUG
@@ -602,7 +715,7 @@ Eigen::VectorXd AxiSymModel::gen_point_3d(double Emin, double Emax,
 #endif
 
   double r, vr, vt, vt1, vt2, E, K, J, jmax, w1t, eee, pot;
-  double phi, sint, cost, sinp, cosp, azi;
+  double phi, sint, cost, sinp, cosp;
   double rmin = max<double>(get_min_radius(), gen_rmin);
   double rmax = get_max_radius();
 
@@ -688,7 +801,8 @@ Eigen::VectorXd AxiSymModel::gen_point_3d(double Emin, double Emax,
 #endif    
   }
 
-				// Enforce limits
+  // Enforce limits
+  //
   Emin = max<double>(Emin, Emin_grid);
   Emin = min<double>(Emin, Emax_grid);
   Emax = max<double>(Emax, Emin_grid);
@@ -733,9 +847,10 @@ Eigen::VectorXd AxiSymModel::gen_point_3d(double Emin, double Emax,
       
   pot = get_pot(r);
   vt = J/r;
-  ierr = 0;
-				// Interpolation check (should be rare)
-				// Error condition is set
+  int ierr = 0;
+
+  // Interpolation check (should be rare).  Error condition is set.
+  //
   if (2.0*(E - pot) - vt*vt < 0.0) {
     ierr = 1;
     if (E < pot) E = pot;
@@ -745,7 +860,9 @@ Eigen::VectorXd AxiSymModel::gen_point_3d(double Emin, double Emax,
 
   if (Unit(random_gen)<0.5) vr *= -1.0;
     
-  azi = 2.0*M_PI*Unit(random_gen);
+  // Orientation of tangential velocity vector
+  //
+  double azi = 2.0*M_PI*Unit(random_gen);
   vt1 = vt*cos(azi);
   vt2 = vt*sin(azi);
 
@@ -767,7 +884,7 @@ Eigen::VectorXd AxiSymModel::gen_point_3d(double Emin, double Emax,
     
 
 #ifdef DEBUG
-  if (ierr) return out;
+  if (ierr) return {out, ierr};
 
   eee = pot + 0.5*(out[4]*out[4]+out[5]*out[5]+out[6]*out[6]);
   orb.new_orbit(eee, 0.5);
@@ -787,15 +904,15 @@ Eigen::VectorXd AxiSymModel::gen_point_3d(double Emin, double Emax,
        << std::endl;
 #endif
 
-  return out;
+  return {out, ierr};
 }
 
 
 
-Eigen::VectorXd AxiSymModel::gen_point_jeans_3d(int& ierr)
+AxiSymModel::PSret AxiSymModel::gen_point_jeans_3d()
 {
   double r, d, vr, vt, vt1, vt2, vv, vtot;
-  double phi, sint, cost, sinp, cosp, azi;
+  double phi, sint, cost, sinp, cosp;
   double rmin = max<double>(get_min_radius(), gen_rmin);
 
   if (gen_firstime_jeans) {
@@ -838,8 +955,8 @@ Eigen::VectorXd AxiSymModel::gen_point_jeans_3d(int& ierr)
 
 
     // Debug
-    
-    ofstream test("test.grid");
+    //
+    std::ofstream test("test.grid");
     if (test) {
 
       test << "# [Jeans] Rmin=" << rmin
@@ -885,7 +1002,9 @@ Eigen::VectorXd AxiSymModel::gen_point_jeans_3d(int& ierr)
   vr = vtot*xxx;
   vt = vtot*sqrt(yyy);
 
-  azi = 2.0*M_PI*Unit(random_gen);
+  // Orientation of tangential velocity vector
+  //
+  double azi = 2.0*M_PI*Unit(random_gen);
   vt1 = vt*cos(azi);
   vt2 = vt*sin(azi);
 
@@ -907,24 +1026,20 @@ Eigen::VectorXd AxiSymModel::gen_point_jeans_3d(int& ierr)
   out[5] = vr * sint*sinp + vt1 * cost*sinp + vt2*cosp;
   out[6] = vr * cost      - vt1 * sint;
     
-  ierr = 0;
-
-  return out;
+  return {out, 0};
 }
 
-void AxiSymModel::gen_velocity(double* pos, double* vel, int& ierr)
+int AxiSymModel::gen_velocity(double* pos, double* vel)
 {
   if (dof()!=3)
       bomb( "AxiSymModel: gen_velocity only implemented for 3d model!" );
-
+  
   if (!dist_defined) {
-    std::cerr << "AxiSymModel: must define distribution before realizing!"
-	      << std::endl;
-    exit (-1);
+    throw std::runtime_error("AxiSymModel: must define distribution before realizing!");
   }
 
   double r, pot, vmax, vr=0.0, vt, eee, vt1=0.0, vt2=0.0, fmax;
-  double phi, sint, cost, sinp, cosp, azi;
+  double phi, sint, cost, sinp, cosp;
   double rmin = max<double>(get_min_radius(), gen_rmin);
 
   double Emax = get_pot(get_max_radius());
@@ -1021,7 +1136,9 @@ void AxiSymModel::gen_velocity(double* pos, double* vel, int& ierr)
 
     if (Unit(random_gen)<0.5) vr *= -1.0;
     
-    azi = 2.0*M_PI*Unit(random_gen);
+    // Orientation of tangential velocity vector
+    //
+    double azi = 2.0*M_PI*Unit(random_gen);
     vt1 = vt*cos(azi);
     vt2 = vt*sin(azi);
 
@@ -1038,12 +1155,9 @@ void AxiSymModel::gen_velocity(double* pos, double* vel, int& ierr)
 		<< std::setw(12) << fmax
 		<< " %=" << std::setw(12)
 		<< static_cast<double>(++toomany)/totcnt << std::endl;
-    ierr = 1;
-    return;
+    return 1;
   }
 
-  ierr = 0;
-  
   if (Unit(random_gen)>=0.5) vr *= -1.0;
 
   phi = atan2(pos[1], pos[0]);
@@ -1055,18 +1169,19 @@ void AxiSymModel::gen_velocity(double* pos, double* vel, int& ierr)
   vel[0] = vr * sint*cosp + vt1 * cost*cosp - vt2*sinp;
   vel[1] = vr * sint*sinp + vt1 * cost*sinp + vt2*cosp;
   vel[2] = vr * cost      - vt1 * sint;
+
+  return 0;
 }
 
-Eigen::VectorXd SphericalModelMulti::gen_point(int& ierr)
+AxiSymModel::PSret SphericalModelMulti::gen_point()
 {
   if (!real->dist_defined || !fake->dist_defined) {
-    std::cerr << "SphericalModelMulti: input distribution functions must be defined before realizing!" << std::endl;
-    exit (-1);
+    throw std::runtime_error("SphericalModelMulti: input distribution functions must be defined before realizing!");
   }
 
   double r, pot, vmax;
   double vr=0.0, vt=0.0, eee=0.0, vt1=0.0, vt2=0.0, fmax, emax;
-  double mass, phi, sint, cost, sinp, cosp, azi;
+  double mass, phi, sint, cost, sinp, cosp;
 
   double Emax = get_pot(get_max_radius());
 
@@ -1271,6 +1386,7 @@ Eigen::VectorXd SphericalModelMulti::gen_point(int& ierr)
   for (it=0; it<gen_itmax; it++) {
 #else
   // Trial phase-space point
+  //
   for (it=0; it<gen_itmax; it++) {
 
     // Generate a radius (inside the loop)
@@ -1308,7 +1424,9 @@ Eigen::VectorXd SphericalModelMulti::gen_point(int& ierr)
 
     if (Unit(random_gen) < 0.5) vr *= -1.0;
     
-    azi = 2.0*M_PI*Unit(random_gen);
+    // Orientation of tangential velocity vector
+    //
+    double azi = 2.0*M_PI*Unit(random_gen);
     vt1 = vt*cos(azi);
     vt2 = vt*sin(azi);
 
@@ -1320,7 +1438,6 @@ Eigen::VectorXd SphericalModelMulti::gen_point(int& ierr)
   static unsigned totcnt = 0, toomany = 0;
   totcnt++;
 
-
   if (it==gen_itmax) {
     if (verbose) {
       std::cerr << "Velocity selection failed [" << myid << "]: r="
@@ -1331,13 +1448,10 @@ Eigen::VectorXd SphericalModelMulti::gen_point(int& ierr)
 		<< " %=" << std::setw(12)
 		<< static_cast<double>(++toomany)/totcnt << std::endl;
     }
-    ierr = 1;
     out.setZero();
-    return out;
+    return {out, 1};
   }
 
-  ierr = 0;
-  
   if (Unit(random_gen)>=0.5) vr *= -1.0;
 
   phi  = 2.0*M_PI*Unit(random_gen);
@@ -1375,24 +1489,23 @@ Eigen::VectorXd SphericalModelMulti::gen_point(int& ierr)
   out[5] = vr * sint*sinp + vt1 * cost*sinp + vt2*cosp;
   out[6] = vr * cost      - vt1 * sint;
     
+  int ierr = 0;
   for (int i=0; i<7; i++) {
     if (std::isnan(out[i]) || std::isinf(out[i])) ierr = 1;
   }
 
-  return out;
+  return {out, ierr};
 }
 
 
-Eigen::VectorXd SphericalModelMulti::gen_point(double radius, int& ierr)
+AxiSymModel::PSret SphericalModelMulti::gen_point(double radius)
 {
   if (!real->dist_defined || !fake->dist_defined) {
-    std::cerr << "SphericalModelMulti: input distribution functions must be defined before realizing!" << std::endl;
-    exit (-1);
+    throw std::runtime_error("SphericalModelMulti: input distribution functions must be defined before realizing!");
   }
 
   double r, pot, vmax;
   double vr=0.0, vt=0.0, eee=0.0, vt1=0.0, vt2=0.0, fmax;
-  double phi, sint, cost, sinp, cosp, azi;
 
   double Emax = get_pot(get_max_radius());
 
@@ -1500,7 +1613,9 @@ Eigen::VectorXd SphericalModelMulti::gen_point(double radius, int& ierr)
 
     if (Unit(random_gen)<0.5) vr *= -1.0;
     
-    azi = 2.0*M_PI*Unit(random_gen);
+    // Orientation of the tangential velocity vector
+    //
+    double azi = 2.0*M_PI*Unit(random_gen);
     vt1 = vt*cos(azi);
     vt2 = vt*sin(azi);
 
@@ -1519,20 +1634,17 @@ Eigen::VectorXd SphericalModelMulti::gen_point(double radius, int& ierr)
 		<< " reject="  << std::setw( 6) << reject
 		<< std::endl;
     }
-    ierr = 1;
     out.setZero();
-    return out;
+    return {out, 1};
   }
 
-  ierr = 0;
-  
   if (Unit(random_gen)>=0.5) vr *= -1.0;
 
-  phi  = 2.0*M_PI*Unit(random_gen);
-  cost = 2.0*(Unit(random_gen) - 0.5);
-  sint = sqrt(1.0 - cost*cost);
-  cosp = cos(phi);
-  sinp = sin(phi);
+  double phi  = 2.0*M_PI*Unit(random_gen);
+  double cost = 2.0*(Unit(random_gen) - 0.5);
+  double sint = sqrt(1.0 - cost*cost);
+  double cosp = cos(phi);
+  double sinp = sin(phi);
 
   double dfr = real->distf(eee, r*vt);
   double dfn = fake->distf(eee, r*vt);
@@ -1560,25 +1672,205 @@ Eigen::VectorXd SphericalModelMulti::gen_point(double radius, int& ierr)
   out[5] = vr * sint*sinp + vt1 * cost*sinp + vt2*cosp;
   out[6] = vr * cost      - vt1 * sint;
     
+  int ierr = 0;
   for (int i=0; i<7; i++) {
     if (std::isnan(out[i]) || std::isinf(out[i])) ierr = 1;
   }
   
-  return out;
+  return {out, ierr};
 }
 
-
-Eigen::VectorXd
-  SphericalModelMulti::gen_point(double Emin, double Emax, double Kmin,
-				 double Kmax, int& ierr)
+AxiSymModel::PSret
+SphericalModelMulti::gen_point(double radius, double theta, double phi)
 {
   if (!real->dist_defined || !fake->dist_defined) {
-    std::cerr << "SphericalModelMulti: input distribution functions must be defined before realizing!" << std::endl;
-    exit (-1);
+    throw std::runtime_error("SphericalModelMulti: input distribution functions must be defined before realizing!");
+  }
+
+  double r, pot, vmax, fmax;
+  double vr=0.0, vt=0.0, eee=0.0, vt1=0.0, vt2=0.0;
+
+  double Emax = get_pot(get_max_radius());
+
+  if (gen_firstime) {
+    double tol = 1.0e-5;
+    double dx = (1.0 - 2.0*tol)/(numr-1);
+    double dy = (1.0 - 2.0*tol)/(numj-1);
+    double dr;
+
+    gen_mass.resize(gen_N);
+    gen_rloc.resize(gen_N);
+    gen_fmax.resize(gen_N);
+
+    if (rmin_gen <= 1.0e-16) gen_logr = 0;
+    
+    if (gen_logr)
+      dr = (log(rmax_gen) - log(rmin_gen))/(gen_N-1);
+    else
+      dr = (rmax_gen - rmin_gen)/(gen_N-1);
+
+    for (int i=0; i<gen_N; i++) {
+
+      if (gen_logr) {
+	gen_rloc[i] = log(rmin_gen) + dr*i;
+	r = exp(gen_rloc[i]);
+      }
+      else {
+	gen_rloc[i] = rmin_gen + dr*i;
+	r = gen_rloc[i];
+      }
+
+      gen_mass[i] = fake->get_mass(r);
+
+      pot = get_pot(r);
+      vmax = sqrt(2.0*fabs(Emax - pot));
+
+      fmax = 0.0;
+      for (int j=0; j<numr; j++) {
+	double xxx = tol + dx*j;
+
+	for (int k=0; k<numj; k++) {
+	  double yyy = tol + dy*k;
+
+	  vr = vmax*xxx;
+	  vt = vmax*sqrt((1.0 - xxx*xxx)*yyy);
+	  eee = pot + 0.5*(vr*vr + vt*vt);
+
+	  double zzz = fake->distf(eee, r*vt);
+	  fmax = zzz>fmax ? zzz : fmax;
+	}
+      }
+      gen_fmax[i] = fmax*(1.0 + ftol);
+
+    }
+
+    // Debug
+    //
+    ofstream test("test_multi.grid");
+    if (test) {
+
+      test << "# Rmin=" << rmin_gen
+	   << "  Rmax=" << rmax_gen
+	   << std::endl;
+
+      for (int i=0; i<gen_N; i++) {
+	test << std::setw(15) << gen_rloc[i]
+	     << std::setw(15) << gen_mass[i]
+	     << std::setw(15) << gen_fmax[i]
+	     << std::setw(15) << get_pot(exp(gen_rloc[i]))
+	     << std::setw(15) << fake->distf(get_pot(exp(gen_rloc[i])), 0.5)
+	     << std::endl;
+      }
+    }
+
+    gen_firstime = false;
+  }
+
+  r    = max<double>(rmin_gen, min<double>(rmax_gen, radius));
+  fmax = odd2(r, gen_rloc, gen_fmax, 1);
+  if (gen_logr) r = exp(r);
+  
+  pot  = get_pot(r);
+  vmax = sqrt(2.0*max<double>(Emax - pot, 0.0));
+
+  // Trial velocity point
+  //
+				// Diagnostic counters
+  int reject=0;
+  int it;			// Iteration counter
+  for (it=0; it<gen_itmax; it++) {
+
+    double xxx = 2.0*sin(asin(Unit(random_gen))/3.0);
+    double yyy = (1.0 - xxx*xxx)*Unit(random_gen);
+
+    vr = vmax*xxx;
+    vt = vmax*sqrt(yyy);
+    eee = pot + 0.5*(vr*vr + vt*vt);
+
+    if (fmax<=0.0) continue;
+
+    if (Unit(random_gen) > fake->distf(eee, r*vt)/fmax ) {
+      reject++;
+      continue;
+    }
+
+    if (Unit(random_gen)<0.5) vr *= -1.0;
+    
+    // Orientation of tangential velocity vector
+    //
+    double azi = 2.0*M_PI*Unit(random_gen);
+    vt1 = vt*cos(azi);
+    vt2 = vt*sin(azi);
+
+    break;
+  }
+                
+  Eigen::VectorXd out(7);
+
+  if (it==gen_itmax) {
+    if (verbose) {
+      static unsigned totcnt = 0;
+      std::cerr << "Velocity selection failed [" << std::setw(7) << ++totcnt
+		<< "," << std::setw(4) << myid << "]: r="
+		<< std::setw(12) << r
+		<< std::setw(12) << fmax
+		<< " reject="  << std::setw( 6) << reject
+		<< std::endl;
+    }
+    out.setZero();
+    return {out, 1};
+  }
+
+  if (Unit(random_gen)>=0.5) vr *= -1.0;
+
+  double dfr = real->distf(eee, r*vt);
+  double dfn = fake->distf(eee, r*vt);
+  double rat = dfr/dfn;
+
+  // Deep debug
+  //
+#ifdef DEBUG
+  if (rat <= 0.0) {
+    std::cout << "[" << std::setw(3) << myid << "] Bad mass: rat="
+	      << std::setw(16) << rat
+	      << " df(M)=" << std::setw(16) << dfr
+	      << " df(N)=" << std::setw(16) << dfn
+	      << " r="     << std::setw(16) << r
+	      << " E="     << std::setw(16) << eee
+	      << std::endl;
+  }
+#endif
+
+  double cost = cos(theta);
+  double sint = sin(theta);
+  double cosp = cos(phi);
+  double sinp = sin(phi);
+
+  out[0] = rat;
+  out[1] = r * sint*cosp;
+  out[2] = r * sint*sinp;
+  out[3] = r * cost;
+  out[4] = vr * sint*cosp + vt1 * cost*cosp - vt2*sinp;
+  out[5] = vr * sint*sinp + vt1 * cost*sinp + vt2*cosp;
+  out[6] = vr * cost      - vt1 * sint;
+    
+  int ierr = 0;
+  for (int i=0; i<7; i++) {
+    if (std::isnan(out[i]) || std::isinf(out[i])) ierr = 1;
+  }
+  
+  return {out, ierr};
+}
+
+AxiSymModel::PSret SphericalModelMulti::gen_point
+(double Emin, double Emax, double Kmin,  double Kmax)
+{
+  if (!real->dist_defined || !fake->dist_defined) {
+    throw std::runtime_error("SphericalModelMulti: input distribution functions must be defined before realizing!");
   }
   
   double r, vr, vt, vt1, vt2, E, K, J, jmax, w1t, pot;
-  double phi, sint, cost, sinp, cosp, azi;
+  double phi, sint, cost, sinp, cosp;
   double rmin = max<double>(get_min_radius(), gen_rmin);
   double rmax = get_max_radius();
 
@@ -1619,7 +1911,9 @@ Eigen::VectorXd
 
       vector<WRgrid> wrvec;
       for (int j=0; j<gen_K; j++) {
-				// Trapezoidal rule factor
+
+	// Trapezoidal rule factor
+	//
 	if (j==0 || j==gen_K) tfac = 0.5;
 	else tfac = 1.0;
 
@@ -1669,7 +1963,8 @@ Eigen::VectorXd
     gen_firstime_E = false;
   }
 
-				// Enforce limits
+  // Enforce limits
+  //
   Emin = max<double>(Emin, Emin_grid);
   Emin = min<double>(Emin, Emax_grid);
   Emax = max<double>(Emax, Emin_grid);
@@ -1714,9 +2009,10 @@ Eigen::VectorXd
       
   pot = get_pot(r);
   vt = J/r;
-  ierr = 0;
-				// Interpolation check (should be rare)
-				// Error condition is set
+
+  // Interpolation check (should be rare). Error condition is set.
+  //
+  int ierr = 0;
   if (2.0*(E - pot) - vt*vt < 0.0) {
     ierr = 1;
     if (E < pot) E = pot;
@@ -1726,7 +2022,9 @@ Eigen::VectorXd
 
   if (Unit(random_gen)<0.5) vr *= -1.0;
     
-  azi = 2.0*M_PI*Unit(random_gen);
+  // Orientation of the tangential velocity vector
+  //
+  double azi = 2.0*M_PI*Unit(random_gen);
   vt1 = vt*cos(azi);
   vt2 = vt*sin(azi);
 
@@ -1750,7 +2048,7 @@ Eigen::VectorXd
     if (std::isnan(out[i]) || std::isinf(out[i])) ierr = 1;
   }
 
-  return out;
+  return {out, ierr};
 }
 
 

--- a/exputil/realize_model.cc
+++ b/exputil/realize_model.cc
@@ -607,7 +607,7 @@ AxiSymModel::PSret AxiSymModel::gen_point_3d(double r, double theta, double phi)
     double dr = (get_max_radius() - rmin)/gen_N;
 
     for (int i=0; i<gen_N; i++) {
-      gen_rloc[i] = rmin + dr*i;
+      gen_rloc[i] = rmin + dr*(0.5+i);
       gen_mass[i] = get_mass(gen_rloc[i]);
 
       pot = get_pot(gen_rloc[i]);
@@ -632,6 +632,18 @@ AxiSymModel::PSret AxiSymModel::gen_point_3d(double r, double theta, double phi)
 
     }
     gen_firstime = false;
+
+    std::ofstream out("gen_point_3d.dat");
+    if (out) {
+      out << "# gen_point_3d[" << ModelID << "]" << std::endl
+	  << "# " << std::setw(14) << "r" << std::setw(16) << "mass"
+	  << std::endl;
+      for (int i=0; i<gen_N; i++) {
+	out << std::setw(16) << gen_rloc[i]
+	    << std::setw(16) << gen_mass[i]
+	    << std::endl;
+      }
+    }
   }
 
   fmax = odd2(r, gen_rloc, gen_fmax, 1);

--- a/exputil/realize_model.cc
+++ b/exputil/realize_model.cc
@@ -799,7 +799,8 @@ AxiSymModel::PSret AxiSymModel::gen_point_3d_iso
 
   // Fibonacci lattice for velocities
   //
-  constexpr double goldenRatio = 0.5*(1.0 + sqrt(5.0));
+  const double goldenRatio = 1.618033988749895;
+
   double vphi  = 2.0*M_PI * ja / goldenRatio;
   double vcost = 1.0 - 2.0*ja/na;
   double vsint = sqrt(fabs(1.0 - vcost*vcost));

--- a/include/massmodel.H
+++ b/include/massmodel.H
@@ -128,7 +128,7 @@ protected:
   bool gen_firstime_jeans;
   Eigen::VectorXd gen_rloc, gen_mass, gen_fmax;
   SphericalOrbit gen_orb;
-  double gen_fomax, gen_ecut;
+  double gen_fomax, gen_ecut, gen_lastr=-1.0;
   //@}
 
   PSret gen_point_2d();
@@ -137,6 +137,9 @@ protected:
   PSret gen_point_3d(double Emin, double Emax, double Kmin, double Kmax);
   PSret gen_point_jeans_3d();
   PSret gen_point_3d(double r, double theta, double phi);
+  PSret gen_point_3d_iso(double r, double theta, double phi,
+			 int N, int nv, int na,
+			 double PHI=0, double THETA=0, double PSI=0);
   
   double Emin_grid, Emax_grid, dEgrid, dKgrid;
   vector<double> Egrid, Kgrid, EgridMass;
@@ -263,6 +266,22 @@ public:
       bomb( "AxiSymModel: gen_point(r, theta, phi) not implemented!" );
     else if (dof()==3)
       return gen_point_3d(r, theta, phi);
+    else
+      bomb( "AxiSymModel: dof must be 2 or 3" );
+    
+    return {Eigen::VectorXd(), 1};
+  }
+  
+  //! Generate a phase-space point at a particular radius, theta, and phi
+  virtual PSret
+  gen_point_iso(double r, double theta, double phi, int N, int nv, int na,
+		double PHI, double THETA, double PSI)
+  {
+    if (dof()==2)
+      bomb( "AxiSymModel: gen_point(r, theta, phi) not implemented!" );
+    else if (dof()==3)
+      return gen_point_3d_iso(r, theta, phi, N, nv, na,
+			      PHI, THETA, PSI);
     else
       bomb( "AxiSymModel: dof must be 2 or 3" );
     

--- a/include/massmodel.H
+++ b/include/massmodel.H
@@ -4,6 +4,7 @@
 #include <vector>
 #include <memory>
 #include <random>
+#include <tuple>
 
 #include <Eigen/Eigen>
 
@@ -111,6 +112,10 @@ public:
 class AxiSymModel : public MassModel,
 		    public std::enable_shared_from_this<AxiSymModel>
 {
+public:
+
+  using PSret = std::tuple<Eigen::VectorXd, int>;
+
 protected:
   //@{
   //! Stuff for gen_point
@@ -126,11 +131,12 @@ protected:
   double gen_fomax, gen_ecut;
   //@}
 
-  Eigen::VectorXd gen_point_2d(int& ierr);
-  Eigen::VectorXd gen_point_2d(double r, int& ierr);
-  Eigen::VectorXd gen_point_3d(int& ierr);
-  Eigen::VectorXd gen_point_3d(double Emin, double Emax, double Kmin, double Kmax, int& ierr);
-  Eigen::VectorXd gen_point_jeans_3d(int& ierr);
+  PSret gen_point_2d();
+  PSret gen_point_2d(double r);
+  PSret gen_point_3d();
+  PSret gen_point_3d(double Emin, double Emax, double Kmin, double Kmax);
+  PSret gen_point_jeans_3d();
+  PSret gen_point_3d(double r, double theta, double phi);
   
   double Emin_grid, Emax_grid, dEgrid, dKgrid;
   vector<double> Egrid, Kgrid, EgridMass;
@@ -212,55 +218,73 @@ public:
   void set_Ecut(double cut) { gen_ecut = cut; }
 
   //! Generate a phase-space point
-  virtual Eigen::VectorXd gen_point(int& ierr) {
+  virtual PSret gen_point()
+  {
     if (dof()==2)
-      return gen_point_2d(ierr);
+      return gen_point_2d();
     else if (dof()==3)
-      return gen_point_3d(ierr);
+      return gen_point_3d();
     else
       bomb( "dof must be 2 or 3" );
     
-    return Eigen::VectorXd();
+    return {Eigen::VectorXd(), 1};
   }
   
   //! Generate a phase-space point using Jeans' equations
-  virtual Eigen::VectorXd gen_point_jeans(int& ierr) {
+  virtual PSret gen_point_jeans()
+  {
     if (dof()==2)
       bomb( "AxiSymModel: gen_point_jeans_2d(ierr) not implemented!" );
     else if (dof()==3)
-      return gen_point_jeans_3d(ierr);
+      return gen_point_jeans_3d();
     else
       bomb( "dof must be 2 or 3" );
     
-    return Eigen::VectorXd();
+    return {Eigen::VectorXd(), 1};
   }
   
   //! Generate a phase-space point at a particular radius
-  virtual Eigen::VectorXd gen_point(double r, int& ierr) {
+  virtual PSret gen_point(double r) {
     if (dof()==2)
-      return gen_point_2d(r, ierr);
+      return gen_point_2d(r);
     else if (dof()==3)
-      bomb( "AxiSymModel: gen_point(r, ierr) not implemented!" );
+      bomb( "AxiSymModel: gen_point(r) not implemented!" );
     else
       bomb( "AxiSymModel: dof must be 2 or 3" );
     
-    return Eigen::VectorXd();
+    return {Eigen::VectorXd(), 1};
+  }
+  
+  //! Generate a phase-space point at a particular radius, theta, and phi
+  virtual PSret
+  gen_point(double r, double theta, double phi)
+  {
+    if (dof()==2)
+      bomb( "AxiSymModel: gen_point(r, theta, phi) not implemented!" );
+    else if (dof()==3)
+      return gen_point_3d(r, theta, phi);
+    else
+      bomb( "AxiSymModel: dof must be 2 or 3" );
+    
+    return {Eigen::VectorXd(), 1};
   }
   
   //! Generate a phase-space point at a particular energy and angular momentum
-  virtual Eigen::VectorXd gen_point(double Emin, double Emax, double Kmin, double Kmax, int& ierr) {
+  virtual PSret
+  gen_point(double Emin, double Emax, double Kmin, double Kmax)
+  {
     if (dof()==2)
-      bomb( "AxiSymModel: gen_point(r, ierr) not implemented!" );
+      bomb( "AxiSymModel: gen_point(r) not implemented!" );
     else if (dof()==3)
-      return gen_point_3d(Emin, Emax, Kmin, Kmax, ierr);
+      return gen_point_3d(Emin, Emax, Kmin, Kmax);
     else
       bomb( "AxiSymModel: dof must be 2 or 3" );
     
-    return Eigen::VectorXd();
+    return {Eigen::VectorXd(), 1};
   }
   
   //! Generate a the velocity variate from a position
-  virtual void gen_velocity(double *pos, double *vel, int& ierr);
+  virtual int gen_velocity(double *pos, double *vel);
   
 };
 
@@ -501,9 +525,10 @@ public:
 
   //@{
   //! Overloaded to provide mass distribution from Real and Number distribution from Fake
-  Eigen::VectorXd gen_point(int& ierr);
-  Eigen::VectorXd gen_point(double r, int& ierr);
-  Eigen::VectorXd gen_point(double Emin, double Emax, double Kmin, double Kmax, int& ierr);
+  PSret gen_point();
+  PSret gen_point(double r);
+  PSret gen_point(double Emin, double Emax, double Kmin, double Kmax);
+  PSret gen_point(double r, double theta, double phi);
   //@}
 
 

--- a/src/Basis.cc
+++ b/src/Basis.cc
@@ -4,7 +4,7 @@
 
 // Machine constant for Legendre
 //
-constexpr double MINEPS = 20.0*std::numeric_limits<double>::min();
+constexpr double MINEPS = 3.0*std::numeric_limits<double>::epsilon();
 
 Basis::Basis(Component* c0, const YAML::Node& conf) : PotAccel(c0, conf)
 {

--- a/utils/ICs/CMakeLists.txt
+++ b/utils/ICs/CMakeLists.txt
@@ -2,7 +2,7 @@
 set(bin_PROGRAMS shrinkics gensph gendisk gendisk2d gsphere pstmod
   empinfo empdump eofbasis eofcomp testcoefs testcoefs2 testdeval
   forcetest hdf52accel forcetest2 cylcache modelfit test2d addsphmod
-  cubeics zangics slabics)
+  cubeics zangics slabics addring)
 
 set(common_LINKLIB OpenMP::OpenMP_CXX MPI::MPI_CXX yaml-cpp exputil
   ${VTK_LIBRARIES} ${HDF5_LIBRARIES} ${HDF5_HL_LIBRARIES}
@@ -87,6 +87,8 @@ add_executable(cubeics cubeICs.cc)
 add_executable(zangics ZangICs.cc)
 
 add_executable(slabics genslab.cc massmodel1d.cc)
+
+add_executable(addring addring.cc)
 
 foreach(program ${bin_PROGRAMS})
   target_link_libraries(${program} ${common_LINKLIB})

--- a/utils/ICs/Disk2dHalo.cc
+++ b/utils/ICs/Disk2dHalo.cc
@@ -401,7 +401,7 @@ void Disk2dHalo::set_halo(vector<Particle>& phalo, int nhalo, int npart)
   for (int i=0; i<npart; i++) {
 
     do {
-      ps = multi->gen_point(ierr);
+      std::tie(ps, ierr) = multi->gen_point();
       if (ierr) count1++;
     } while (ierr);
     
@@ -2329,7 +2329,7 @@ void Disk2dHalo::set_vel_halo(vector<Particle>& part)
 				// Use Eddington
     
     if (DF && 0.5*(1.0+erf((r-R_DF)/DR_DF)) > rndU(gen)) {
-      halo2->gen_velocity(&p.pos[0], &p.vel[0], nok);
+      nok = halo2->gen_velocity(&p.pos[0], &p.vel[0]);
       
       if (nok) {
 	std::cout << "gen_velocity failed: "

--- a/utils/ICs/DiskHalo.cc
+++ b/utils/ICs/DiskHalo.cc
@@ -411,7 +411,7 @@ void DiskHalo::set_halo(vector<Particle>& phalo, int nhalo, int npart)
   for (int i=0; i<npart; i++) {
 
     do {
-      ps = multi->gen_point(ierr);
+      std::tie(ps, ierr) = multi->gen_point();
       if (ierr) count1++;
     } while (ierr);
     
@@ -631,7 +631,7 @@ set_halo_coordinates(vector<Particle>& phalo, int nhalo, int npart)
     p.pos[2] = r*costh;
 
     do {
-      ps = halo2->gen_point(ierr);
+      std::tie(ps, ierr) = halo2->gen_point();
     } while (ierr);
 
     massp1 += p.mass;
@@ -2560,7 +2560,8 @@ void DiskHalo::set_vel_halo(vector<Particle>& part)
 				// Use Eddington
     
     if (DF && 0.5*(1.0+erf((r-R_DF)/DR_DF)) > rndU(gen)) {
-      halo2->gen_velocity(&p.pos[0], &p.vel[0], nok);
+
+      nok = halo2->gen_velocity(&p.pos[0], &p.vel[0]);
       
       if (nok) {
 	std::cout << "gen_velocity failed: "

--- a/utils/ICs/addring.cc
+++ b/utils/ICs/addring.cc
@@ -1,0 +1,192 @@
+/*
+  Add a ring of particles to an existing realization
+*/
+
+#include <filesystem>
+#include <iostream>
+#include <iomanip>
+#include <fstream>
+#include <sstream>
+#include <cstdlib>
+#include <string>
+#include <random>
+#include <vector>
+#include <cmath>
+
+#include <Eigen/Eigen>
+
+#include <fenv.h>
+
+#include <config_exp.h>
+#ifdef HAVE_OMP_H
+#include <omp.h>
+#endif
+
+// EXP classes
+//
+#include <numerical.H>
+#include <gaussQ.H>
+#include <isothermal.H>
+#include <hernquist_model.H>
+#include <model3d.H>
+#include <biorth.H>
+#include <SphericalSL.H>
+#include <interp.H>
+#include <AddSpheres.H>
+#include <libvars.H>		// Library globals
+#include <cxxopts.H>		// Command-line parsing
+#include <EXPini.H>		// Ini-style config
+
+                                // Local headers
+#include <SphericalSL.H>
+#include <localmpi.H>
+
+int
+main(int ac, char **av)
+{
+  //====================
+  // Inialize MPI stuff
+  //====================
+
+  local_init_mpi(ac, av);
+
+  //====================
+  // Begin opt parsing
+  //====================
+
+  std::string  halofile;
+  int          DIVERGE, N;
+  double       DIVERGE_RFAC, mass, radius, width, vdisp;
+  std::string  outfile, config;
+
+  const std::string mesg("Make a model from the combination of two spherical models.  E.g. a DM halo and a bulge.\n");
+
+  cxxopts::Options options(av[0], mesg);
+
+  options.add_options()
+    ("h,help", "Print this help message")
+    ("s,spline", "Set interplation in SphericalModelTable to 'spline' (default: linear)")
+    ("T,template", "Write template options file with current and all default values")
+    ("c,config", "Parameter configuration file",
+     cxxopts::value<string>(config))
+    ("N,number", "Number of particles",
+     cxxopts::value<int>(N)->default_value("100000"))
+    ("DIVERGE", "Cusp power-law density extrapolation (0 means off)",
+     cxxopts::value<int>(DIVERGE)->default_value("0"))
+    ("DIVERGE_RFAC", "Exponent for inner cusp extrapolation",
+     cxxopts::value<double>(DIVERGE_RFAC)->default_value("1.0"))
+    ("i,halofile", "Halo spherical model table",
+     cxxopts::value<string>(halofile)->default_value("SLGridSph.one"))
+    ("o,outfile", "Output particle file",
+     cxxopts::value<string>(outfile)->default_value("addring.bods"))
+    ("M,mass", "Mass of ring",
+     cxxopts::value<double>(mass)->default_value("0.1"))
+    ("R,radius", "Radius of ring",
+     cxxopts::value<double>(radius)->default_value("1.0"))
+    ("W,width", "Width of ring",
+     cxxopts::value<double>(width)->default_value("0.1"))
+    ("V,disp", "Velocity dispersion",
+     cxxopts::value<double>(vdisp)->default_value("0.1"))
+    ;
+
+  cxxopts::ParseResult vm;
+
+  try {
+    vm = options.parse(ac, av);
+  } catch (cxxopts::OptionException& e) {
+    if (myid==0) std::cout << "Option error: " << e.what() << std::endl;
+    MPI_Finalize();
+    exit(-1);
+  }
+
+  // Write YAML template config file and exit
+  //
+  if (vm.count("template")) {
+    // Write template file
+    //
+    if (myid==0) SaveConfig(vm, options, "template.yaml");
+
+    MPI_Finalize();
+    return 0;
+  }
+
+  // Print help message and exit
+  //
+  if (vm.count("help")) {
+    if (myid == 0) {
+      std::cout << options.help() << std::endl << std::endl
+		<< "Examples: " << std::endl
+		<< "\t" << "Use parameters read from a YAML config file"  << std::endl
+		<< "\t" << av[0] << " --config=addsphmod.config"  << std::endl << std::endl
+		<< "\t" << "Generate a template YAML config file from current defaults"  << std::endl
+		<< "\t" << av[0] << " --template=template.yaml" << std::endl << std::endl;
+    }
+    MPI_Finalize();
+    return 0;
+  }
+
+  // Read parameters fron the YAML config file
+  //
+  if (vm.count("config")) {
+    try {
+      vm = LoadConfig(options, config);
+    } catch (cxxopts::OptionException& e) {
+      if (myid==0) std::cout << "Option error in configuration file: "
+			     << e.what() << std::endl;
+      MPI_Finalize();
+      return 0;
+    }
+  }
+
+  if (vm.count("spline")) {
+    SphericalModelTable::linear = 0;
+  } else {
+    SphericalModelTable::linear = 1;
+  }
+
+  // Open output file
+  //
+  std::ofstream out(outfile);
+  if (not out) throw std::runtime_error("Cannot open output file " + outfile);
+
+  // Model
+  //
+  SphericalModelTable model(halofile, DIVERGE, DIVERGE_RFAC);
+
+
+  // Random setup
+  //
+  std::random_device rd{};
+  std::mt19937 gen{rd()};
+ 
+  // Unit normal distribution
+  //
+  std::normal_distribution<> d{0.0, 1.0};
+  std::uniform_real_distribution<> u{0.0, 1.0};
+  
+ 
+  double pmass = mass/N;
+  Eigen::Vector3d pos, vel;
+  
+  for (int i=0; i<N; i++) {
+
+    double R  = radius + 0.5*width*d(gen);
+    double v0 = sqrt(model.get_mass(radius)/radius);
+    double phi = 2.0*M_PI*u(gen);
+
+    pos(0) = R*cos(phi);
+    pos(1) = R*sin(phi);
+    pos(2) = 0.5*width*d(gen);
+    
+    vel(0) = vdisp*d(gen) - v0*sin(phi);
+    vel(1) = vdisp*d(gen) + v0*cos(phi);
+    vel(2) = vdisp*d(gen);
+    
+    out << std::setw(18) << pmass;
+    for (int k=0; k<3; k++) out << std::setw(18) << pos(k);
+    for (int k=0; k<3; k++) out << std::setw(18) << vel(k);
+    out << std::endl;
+  }
+
+  return 0;
+}

--- a/utils/ICs/gensph.cc
+++ b/utils/ICs/gensph.cc
@@ -78,6 +78,8 @@ main(int argc, char **argv)
   bool VTEST;
   std::string INFILE, MMFILE, OUTFILE, OUTPS, config;
 
+  const double goldenRatio = 1.618033988749895;
+
 #ifdef DEBUG
   set_fpu_handler();
 #endif
@@ -769,8 +771,6 @@ main(int argc, char **argv)
       rmass[i] = zbrent(loc, rmin, rmax, 1.0e-8);
     }
   }
-
-  constexpr double goldenRatio = 0.5*(1.0 + sqrt(5.0));
 
   for (int n=beg; n<end; n++) {
 

--- a/utils/ICs/gensph.cc
+++ b/utils/ICs/gensph.cc
@@ -522,6 +522,16 @@ main(int argc, char **argv)
 
   }
 
+  int nradial=0, nphi=0, ncost=0;
+  if (Vquiet) {
+    nphi = 2*Vquiet;
+    ncost = Vquiet;
+    nradial = floor(N/(nphi*ncost));
+
+    // Reset N
+    N = nradial*nphi*ncost;
+  }
+
   double mass = hmodel->get_mass(hmodel->get_max_radius())/N;
   AxiSymModPtr rmodel = hmodel;
 
@@ -706,12 +716,7 @@ main(int argc, char **argv)
   Eigen::VectorXd zz = Eigen::VectorXd::Zero(7);
 
   std::vector<double> rmass;
-  int nradial=0, nphi=0, ncost=0;
   if (Vquiet) {
-    nphi = 2*Vquiet;
-    ncost = Vquiet;
-    nradial = floor(N/(nphi*ncost));
-    if (nradial*nphi*ncost < N) nradial++;
     rmass.resize(nradial);
 
     // Set up mass grid


### PR DESCRIPTION
## Summary of changes
- Added a new routine, `addring` to generate a phase-space torus of material with a Gaussian velocity dispersion given a spherical halo model
- Fixed an error in the `AxiSymModel:gen_point` routine for particles at a given radius. This was *not* previously used by `gensph`.
- Updated `AxiSymModel::gen_point` routines to support new quiet-start methods implemented in `gensph`.  These include distributing particles on a spherical position 'grid', distributing particles on a spherical position and velocity grid, Sellwood's quiet-start orbital plane algorithm, the same algorithm where orbital planes are simultaneously distributed on the sphere using a Fibonacci sequence
- Updated internal code in the model realization routines to use `const` values for algorithm constants rather than preprocessor values.

## Comments
None of these changes affect existing `EXP` or `pyEXP` behavior.   Perhaps `addring` might be dropped from this PR as too specific and idiosyncratic?