### PR TITLE
Check for valid output directory for FieldGenerator methods that write files

### DIFF
--- a/expui/FieldGenerator.cc
+++ b/expui/FieldGenerator.cc
@@ -1,3 +1,4 @@
+#include <filesystem>
 #include <algorithm>
 #include <iomanip>
 #include <sstream>
@@ -259,6 +260,14 @@ namespace Field
 				  const std::string      prefix,
 				  const std::string      outdir)
   {
+    if (myid==0) {
+      // Verify existence of directory
+      bool filepathExists = std::filesystem::is_directory(outdir);
+      if (not filepathExists)
+	throw std::runtime_error("FieldGenerator::file_lines: directory <" +
+				 outdir + "> does not exist");
+    }
+
     auto db = lines(basis, coefs, beg, end, num);
 
     if (myid==0) {
@@ -505,6 +514,14 @@ namespace Field
 				   const std::string      prefix,
 				   const std::string      outdir)
   {
+    if (myid==0) {
+      // Verify existence of directory
+      bool filepathExists = std::filesystem::is_directory(outdir);
+      if (not filepathExists)
+	throw std::runtime_error("FieldGenerator::file_slices: directory <" +
+				 outdir + "> does not exist");
+    }
+
     auto db = slices(basis, coefs);
 
     if (myid==0) {
@@ -710,6 +727,14 @@ namespace Field
 				    const std::string      prefix,
 				    const std::string      outdir)
   {
+    if (myid==0) {
+      // Verify existence of directory
+      bool filepathExists = std::filesystem::is_directory(outdir);
+      if (not filepathExists)
+	throw std::runtime_error("FieldGenerator::file_volumes: directory <" +
+				 outdir + "> does not exist");
+    }
+
     auto db = volumes(basis, coefs);
 
     int bunch = db.size()/numprocs;

--- a/exputil/VtkGrid.cc
+++ b/exputil/VtkGrid.cc
@@ -182,9 +182,9 @@ void VtkGrid::Add(const std::vector<double>& data, const std::string& name)
   //
   int I = 0;
 
-  for (int i=0; i<nx; i++) {
+  for (int k=0; k<nz; k++) {
     for (int j=0; j<ny; j++) {
-      for (int k=0; k<nz; k++) {
+      for (int i=0; i<nx; i++) {
 	dataSet[newName][I++] = static_cast<float>(data[(k*ny + j)*nx + i]);
       }
     }

--- a/pyEXP/FieldWrappers.cc
+++ b/pyEXP/FieldWrappers.cc
@@ -399,10 +399,7 @@ void FieldGeneratorClasses(py::module &m) {
 
         See also
         --------
-<<<<<<< HEAD
-=======
         points : generate fields at an array of mesh points
->>>>>>> pointMesh
         slices : generate fields in a surface slice given by the
                  initializtion grid
         volumes : generate fields in volume given by the initializtion grid


### PR DESCRIPTION
## Summary

Add checks using `std::filesystem` to check that the `outdir` parameter passed to `FieldGenerator::file_lines`, `FiledGenerator::file_slices` , and `FieldGenerator::file_volumes` is valid and throw a standard exception rather than terminate if the provided directory does not exist.

Tested by providing valid and invalid directories to `FieldGenerator::file_volumes`.

## Comment

I also note that the standalone vtk volume writer appears to have transposed axes.  Need to check this.  The `pyEXP.fields.volumes` provides a 3-tensor that needs to be converted from column-major to row-major, but otherwise looks correct.