### PR TITLE
Ensure that `FlatDisk` has a backround if `M0_BACK` is selected in `PolarBasis`

### DIFF
--- a/expui/FieldGenerator.cc
+++ b/expui/FieldGenerator.cc
@@ -1,3 +1,4 @@
+#include <filesystem>
 #include <algorithm>
 #include <iomanip>
 #include <sstream>
@@ -259,6 +260,14 @@ namespace Field
 				  const std::string      prefix,
 				  const std::string      outdir)
   {
+    if (myid==0) {
+      // Verify existence of directory
+      bool filepathExists = std::filesystem::is_directory(outdir);
+      if (not filepathExists)
+	throw std::runtime_error("FieldGenerator::file_lines: directory <" +
+				 outdir + "> does not exist");
+    }
+
     auto db = lines(basis, coefs, beg, end, num);
 
     if (myid==0) {
@@ -505,6 +514,14 @@ namespace Field
 				   const std::string      prefix,
 				   const std::string      outdir)
   {
+    if (myid==0) {
+      // Verify existence of directory
+      bool filepathExists = std::filesystem::is_directory(outdir);
+      if (not filepathExists)
+	throw std::runtime_error("FieldGenerator::file_slices: directory <" +
+				 outdir + "> does not exist");
+    }
+
     auto db = slices(basis, coefs);
 
     if (myid==0) {
@@ -710,6 +727,14 @@ namespace Field
 				    const std::string      prefix,
 				    const std::string      outdir)
   {
+    if (myid==0) {
+      // Verify existence of directory
+      bool filepathExists = std::filesystem::is_directory(outdir);
+      if (not filepathExists)
+	throw std::runtime_error("FieldGenerator::file_volumes: directory <" +
+				 outdir + "> does not exist");
+    }
+
     auto db = volumes(basis, coefs);
 
     int bunch = db.size()/numprocs;

--- a/exputil/VtkGrid.cc
+++ b/exputil/VtkGrid.cc
@@ -182,9 +182,9 @@ void VtkGrid::Add(const std::vector<double>& data, const std::string& name)
   //
   int I = 0;
 
-  for (int i=0; i<nx; i++) {
+  for (int k=0; k<nz; k++) {
     for (int j=0; j<ny; j++) {
-      for (int k=0; k<nz; k++) {
+      for (int i=0; i<nx; i++) {
 	dataSet[newName][I++] = static_cast<float>(data[(k*ny + j)*nx + i]);
       }
     }

--- a/pyEXP/FieldWrappers.cc
+++ b/pyEXP/FieldWrappers.cc
@@ -399,10 +399,7 @@ void FieldGeneratorClasses(py::module &m) {
 
         See also
         --------
-<<<<<<< HEAD
-=======
         points : generate fields at an array of mesh points
->>>>>>> pointMesh
         slices : generate fields in a surface slice given by the
                  initializtion grid
         volumes : generate fields in volume given by the initializtion grid

--- a/src/FlatDisk.cc
+++ b/src/FlatDisk.cc
@@ -109,7 +109,7 @@ void FlatDisk::initialize()
   if (dump_basis) ortho->dump_basis(runtag);
 
   // Set background model
-  if (conf["background"]) setBackground();
+  if (M0_back) setBackground();
 }
 
 FlatDisk::~FlatDisk(void)
@@ -121,8 +121,17 @@ FlatDisk::~FlatDisk(void)
 void FlatDisk::setBackground()
 {
   try {
+    YAML::Node Params;
 
-    YAML::Node Params = conf["background"];
+    if (conf["background"]) Params = conf["background"];
+    else {
+      Params = conf["diskconf"];
+      if (myid==0)		// Log file message
+	std::cout << "---- FlatDisk::setBackground: "
+		  << "M0_BACK set without a 'background' profile" << std::endl
+		  << "---- FlatDisk::setBackground: "
+		  << "using 'diskconf' for 'background' profile" << std::endl;
+    }
 
     std::string name = Params["name"].as<std::string>();
     auto params      = Params["parameters"];


### PR DESCRIPTION
This minor change checks that the user has specified a background potential if `M0_BACK` is selected.  Otherwise, `exp` will seg fault by trying to call a null function.   That is not pretty.  It's really a user error but no one wants to see a seg fault.