### PR TITLE
Disambiguate the sign (phase) of the mSSA PCs

### DIFF
--- a/expui/CMakeLists.txt
+++ b/expui/CMakeLists.txt
@@ -38,7 +38,7 @@ endif()
 set(expui_SOURCES BasisFactory.cc BiorthBasis.cc FieldBasis.cc
   CoefContainer.cc CoefStruct.cc FieldGenerator.cc expMSSA.cc
   Coefficients.cc KMeans.cc Centering.cc ParticleIterator.cc
-  Koopman.cc BiorthBess.cc)
+  Koopman.cc BiorthBess.cc SvdSignChoice.cc)
 add_library(expui ${expui_SOURCES})
 set_target_properties(expui PROPERTIES OUTPUT_NAME expui)
 target_include_directories(expui PUBLIC ${common_INCLUDE})

--- a/expui/SvdSignChoice.cc
+++ b/expui/SvdSignChoice.cc
@@ -31,7 +31,7 @@ namespace MSSA {
   {
     // SDV dimensions
     int I = U.rows();
-    int J = V.cols();
+    int J = V.rows();
     int K = S.size();
     
     // Dimensions
@@ -45,7 +45,7 @@ namespace MSSA {
     if (U.cols() != K)
       throw std::invalid_argument("SvdSignChoice: U has wrong dimensions");
     
-    if (V.rows() != K)
+    if (V.cols() != K)
       throw std::invalid_argument("SvdSignChoice: V has wrong dimensions");
     
     if (X.rows() != I || X.cols() != J)

--- a/expui/SvdSignChoice.cc
+++ b/expui/SvdSignChoice.cc
@@ -57,19 +57,14 @@ namespace MSSA {
     sL.setZero();
     sR.setZero();
     
-    // Working, non-const instance
-    auto S1 = S;
-    
     // Get projections from left and right singular vectors onto data
     // matrix
     //
+#pragma omp parallel for
     for (int k=0; k<K; k++) {
       // Remove all but target dimension for numerical stability
-      S1(k) = 0.0;
+      auto S1 = S; S1(k) = 0.0;
       auto Y = X - U * S1.asDiagonal() * V.transpose();
-
-      // Restore the value
-      S1(k) = S(k);
 
       // d_j = U^T_k * Y_j
       Eigen::VectorXd dL = Y.transpose() * U.col(k);
@@ -91,6 +86,7 @@ namespace MSSA {
     
     // Determine and apply the sign correction
     //
+#pragma omp parallel for
     for (int k=0; k<K; k++) {
       // If signs are opposite, flip the one with the smaller absolute
       // value
@@ -142,19 +138,14 @@ namespace MSSA {
     sL.setZero();
     sR.setZero();
     
-    // Working, non-const instance
-    auto S1 = S;
-    
     // Get projections from left and right singular vectors onto data
     // matrix
     //
+#pragma omp parallel for
     for (int k=0; k<K; k++) {
       // Remove all but target dimension for numerical stability
-      S1(k) = 0.0;
+      auto S1 = S; S1(k) = 0.0;
       auto Y = X - U * S1.asDiagonal() * V.transpose();
-
-      // Restore the value
-      S1(k) = S(k);
 
       // d_j = U^T_k * Y_j
       Eigen::VectorXd dL = Y.transpose() * U.col(k);
@@ -176,6 +167,7 @@ namespace MSSA {
     
     // Determine and apply the sign correction
     //
+#pragma omp parallel for
     for (int k=0; k<K; k++) {
       // If signs are opposite, flip the one with the smaller absolute
       // value
@@ -226,19 +218,14 @@ namespace MSSA {
     sL.setZero();
     sR.setZero();
     
-    // Working, non-const instance
-    auto S1 = S;
-    
     // Get projections from left and right singular vectors onto data
     // matrix
     //
+#pragma omp parallel for
     for (int k=0; k<K; k++) {
       // Remove all but target dimension for numerical stability
-      S1(k) = 0.0;
+      auto S1 = S; S1(k) = 0.0;
       auto Y = X - U * S1.asDiagonal() * V.transpose();
-
-      // Restore the value
-      S1(k) = S(k);
 
       // d_j = U^T_k * Y_j
       Eigen::VectorXd dL = Y.transpose() * U.col(k);
@@ -260,6 +247,7 @@ namespace MSSA {
     
     // Determine and apply the sign correction
     //
+#pragma omp parallel for
     for (int k=0; k<K; k++) {
       // If signs are opposite, flip the one with the smaller absolute
       // value

--- a/expui/SvdSignChoice.cc
+++ b/expui/SvdSignChoice.cc
@@ -1,0 +1,110 @@
+#include <Eigen/Dense>
+
+namespace MSSA {
+
+  // SVD with corrected signs
+  //
+  // Input
+  // -----
+  // X is data matrix (constant)
+  // U is the matrix of left singular vectors
+  // S is the array of singular values (constant)
+  // V is the matrix of right singular vectors
+  //
+  // Output
+  // ------
+  // U, V returned corrected, disambiguated signs
+  //
+  // Reference
+  // ---------
+  // Bro, R., Acar, E., & Kolda, T. G. (2008). Resolving the sign
+  // ambiguity in the singular value decomposition.  Journal of
+  // Chemometrics: A Journal of the Chemometrics Society, 22(2),
+  // 135-140.
+  //
+  // URL:
+  // https://prod-ng.sandia.gov/techlib-noauth/access-control.cgi/2007/076422.pdf
+  //
+  void SvdSignChoice
+  (const Eigen::MatrixXd& X,
+   Eigen::MatrixXd& U, const Eigen::VectorXd& S, Eigen::MatrixXd& V)
+  {
+    // SDV dimensions
+    int I = U.rows();
+    int J = V.cols();
+    int K = S.size();
+    
+    // Dimensions
+    // ----------
+    // X is a [I x J] data matrix
+    // U is a [I x K] matrix
+    // S is a [K x 1] vector (diagonal matrix)
+    // V is a [J x K] matrix
+    
+    // Sanity checks
+    if (U.cols() != K)
+      throw std::invalid_argument("SvdSignChoice: U has wrong dimensions");
+    
+    if (V.rows() != K)
+      throw std::invalid_argument("SvdSignChoice: V has wrong dimensions");
+    
+    if (X.rows() != I || X.cols() != J)
+      throw std::invalid_argument("SvdSignChoice: X dimensions do not match SVD input");
+    
+    // Sign determination loop
+    //
+    Eigen::VectorXd sL(K), sR(K);
+    sL.setZero();
+    sR.setZero();
+    
+    auto S1 = S;
+    
+    auto sgn = [](double val) -> int
+    {
+      return (0.0 < val) - (val < 0.0);
+    };
+    
+    // Get projects from left and right singular vectors onto data matrix
+    //
+    for (int k=0; k<K; k++) {
+      
+      // Remove all but target dimension for numerical stability
+      S1(k) = 0.0;
+      auto Y = X - U * S1.asDiagonal() * V.transpose();
+      S1(k) = S(k);
+      
+      // d_j = U^T_k * Y_j
+      for (int j=0; j<Y.cols(); j++) {
+	double d = U.col(k).dot(Y.col(j));
+	sL(k) += sgn(d) * d*d;
+      }
+      
+      // d_i = V^T_k * (Y^T)_i
+      for (int i=0; i<Y.rows(); i++) {
+	double d = V.col(k).dot(Y.row(i));
+	sR(k) += sgn(d) * d*d;
+      }
+    }
+    
+    
+    // Determine and apply the sign correction
+    //
+    for (int k=0; k<K; k++) {
+      // If signs are opposite, flip the one with the smaller absolute
+      // value
+      //
+      if (sL(k)*sR(k) < 0.0) {
+	if (std::abs(sL(k)) < std::abs(sR(k)))
+	  sL(k) = -sL(k);
+	else
+	  sR(k) = -sR(k);
+      }
+      
+      // Apply
+      U.col(k) *= sgn(sL(k));
+      V.col(k) *= sgn(sR(k));
+    }
+    
+    // Done
+  }
+}

--- a/expui/SvdSignChoice.cc
+++ b/expui/SvdSignChoice.cc
@@ -109,4 +109,173 @@ namespace MSSA {
     
     // Done
   }
+
+  void SvdSignChoice
+  (const Eigen::MatrixXd& X,
+   Eigen::MatrixXd& U, const Eigen::VectorXd& S, const Eigen::MatrixXd& V)
+  {
+    // SDV dimensions
+    int I = U.rows();
+    int J = V.rows();
+    int K = S.size();
+    
+    // Dimensions
+    // ----------
+    // X is a [I x J] data matrix
+    // U is a [I x K] matrix
+    // S is a [K x 1] vector (diagonal matrix)
+    // V is a [J x K] matrix
+    
+    // Sanity checks
+    if (U.cols() != K)
+      throw std::invalid_argument("SvdSignChoice: U has wrong dimensions");
+    
+    if (V.cols() != K)
+      throw std::invalid_argument("SvdSignChoice: V has wrong dimensions");
+    
+    if (X.rows() != I || X.cols() != J)
+      throw std::invalid_argument("SvdSignChoice: X dimensions do not match SVD input");
+    
+    // Sign determination loop
+    //
+    Eigen::VectorXd sL(K), sR(K);
+    sL.setZero();
+    sR.setZero();
+    
+    // Working, non-const instance
+    auto S1 = S;
+    
+    // Get projections from left and right singular vectors onto data
+    // matrix
+    //
+    for (int k=0; k<K; k++) {
+      // Remove all but target dimension for numerical stability
+      S1(k) = 0.0;
+      auto Y = X - U * S1.asDiagonal() * V.transpose();
+
+      // Restore the value
+      S1(k) = S(k);
+
+      // d_j = U^T_k * Y_j
+      Eigen::VectorXd dL = Y.transpose() * U.col(k);
+
+      // sum of sgn(dL_j)*dL_j^2
+      sL(k) += dL.dot(dL.cwiseAbs());
+
+      // d_i = V^T_k * (Y^T)_i
+      Eigen::VectorXd dR = Y * V.col(k);
+
+      // sum of sgn(dR_i)*dR_i^2
+      sR(k) += dR.dot(dR.cwiseAbs());
+    }
+    
+    auto sgn = [](double val) -> int
+    {
+      return (0.0 < val) - (val < 0.0);
+    };
+    
+    // Determine and apply the sign correction
+    //
+    for (int k=0; k<K; k++) {
+      // If signs are opposite, flip the one with the smaller absolute
+      // value
+      //
+      if (sL(k)*sR(k) < 0.0) {
+	if (std::abs(sL(k)) < std::abs(sR(k)))
+	  sL(k) = -sL(k);
+	else
+	  sR(k) = -sR(k);
+      }
+      
+      // Apply
+      U.col(k) *= sgn(sL(k));
+    }
+    
+    // Done
+  }
+
+  void SvdSignChoice
+  (const Eigen::MatrixXd& X,
+   const Eigen::MatrixXd& U, const Eigen::VectorXd& S, Eigen::MatrixXd& V)
+  {
+    // SDV dimensions
+    int I = U.rows();
+    int J = V.rows();
+    int K = S.size();
+    
+    // Dimensions
+    // ----------
+    // X is a [I x J] data matrix
+    // U is a [I x K] matrix
+    // S is a [K x 1] vector (diagonal matrix)
+    // V is a [J x K] matrix
+    
+    // Sanity checks
+    if (U.cols() != K)
+      throw std::invalid_argument("SvdSignChoice: U has wrong dimensions");
+    
+    if (V.cols() != K)
+      throw std::invalid_argument("SvdSignChoice: V has wrong dimensions");
+    
+    if (X.rows() != I || X.cols() != J)
+      throw std::invalid_argument("SvdSignChoice: X dimensions do not match SVD input");
+    
+    // Sign determination loop
+    //
+    Eigen::VectorXd sL(K), sR(K);
+    sL.setZero();
+    sR.setZero();
+    
+    // Working, non-const instance
+    auto S1 = S;
+    
+    // Get projections from left and right singular vectors onto data
+    // matrix
+    //
+    for (int k=0; k<K; k++) {
+      // Remove all but target dimension for numerical stability
+      S1(k) = 0.0;
+      auto Y = X - U * S1.asDiagonal() * V.transpose();
+
+      // Restore the value
+      S1(k) = S(k);
+
+      // d_j = U^T_k * Y_j
+      Eigen::VectorXd dL = Y.transpose() * U.col(k);
+
+      // sum of sgn(dL_j)*dL_j^2
+      sL(k) += dL.dot(dL.cwiseAbs());
+
+      // d_i = V^T_k * (Y^T)_i
+      Eigen::VectorXd dR = Y * V.col(k);
+
+      // sum of sgn(dR_i)*dR_i^2
+      sR(k) += dR.dot(dR.cwiseAbs());
+    }
+    
+    auto sgn = [](double val) -> int
+    {
+      return (0.0 < val) - (val < 0.0);
+    };
+    
+    // Determine and apply the sign correction
+    //
+    for (int k=0; k<K; k++) {
+      // If signs are opposite, flip the one with the smaller absolute
+      // value
+      //
+      if (sL(k)*sR(k) < 0.0) {
+	if (std::abs(sL(k)) < std::abs(sR(k)))
+	  sL(k) = -sL(k);
+	else
+	  sR(k) = -sR(k);
+      }
+      
+      // Apply
+      V.col(k) *= sgn(sR(k));
+    }
+    
+    // Done
+  }
+
 }

--- a/expui/expMSSA.H
+++ b/expui/expMSSA.H
@@ -33,7 +33,8 @@ namespace MSSA
     //! Primary MSSA analysis
     void mssa_analysis();
 
-    bool computed, reconstructed, trajectory;
+    //! MSSA control flags
+    bool computed, reconstructed, trajectory, useSignChoice;
 
     //! The reconstructed coefficients for each PC
     std::map<Key, Eigen::MatrixXd, mSSAkeyCompare> RC;

--- a/expui/expMSSA.cc
+++ b/expui/expMSSA.cc
@@ -55,8 +55,6 @@
 
 namespace MSSA {
 
-  const bool useSignChoice = true;
-
   void SvdSignChoice
   (const Eigen::MatrixXd& X,
    Eigen::MatrixXd& U, const Eigen::VectorXd& S, Eigen::MatrixXd& V);
@@ -1281,6 +1279,7 @@ namespace MSSA {
     "Traj",
     "RedSym",
     "rank",
+    "Sign",
     "allchan",
     "distance",
     "flip",
@@ -1841,7 +1840,7 @@ namespace MSSA {
   }
 
 
-  expMSSA::expMSSA(const mssaConfig& config, int nW, int nPC, const std::string flags) : numW(nW), npc(nPC), trajectory(true)
+  expMSSA::expMSSA(const mssaConfig& config, int nW, int nPC, const std::string flags) : numW(nW), npc(nPC), trajectory(true), useSignChoice(false)
   {
     // Parse the YAML string
     //
@@ -1860,7 +1859,8 @@ namespace MSSA {
 
     // Set the SVD strategy for mSSA
     //
-    if (params["Traj"]) trajectory = params["Traj"].as<bool>();
+    if (params["Traj"]) trajectory    = params["Traj"].as<bool>();
+    if (params["Sign"]) useSignChoice = params["Sign"].as<bool>();
 
     // std::cout << "Trajectory is " << std::boolalpha << trajectory
     // << std::endl;


### PR DESCRIPTION
### Problem

Signs of SVD left and right singular values have ambiguous signs.  Subsequent SVD invocations in `expMSSA` can result in PCs with different signs (i.e. pi radians out of phase).

### Fix

Choose signs of the vectors in the eigen triple based on their squared-norm-weight projection on the original data matrix (either the trajectory or covariance matrix, in our case).

### Comments

The algorithm is implemented in a helper function called `SvdSignChoice`.  This routine has been checked by decomposing a run of random matrices and confirming that the algorithm reconstructs the input data to machine precision after the sign choice is applied.

There is one *big* down side: this literal algorithm is slow since it's passing through the entire trajectory matrix.   I have tried to speed this up by striding the sampling the trajectory so that the number of samples equals the rank rather than a full computation.  But the resulting inefficiency was large, so it wasn't helpful. 

The addition to `expMSSA` is then trivial.  I have included a config flag, `Sign` to turn this algorithm on and off, if need be.    It is now `on` by default.  Code has been tested on the `pyEXP-examples/Tutorials/mSSA` notebooks.