### PR TITLE
Minor update the pyEXP CoefStruct interface

### DIFF
--- a/expui/BiorthBasis.cc
+++ b/expui/BiorthBasis.cc
@@ -24,6 +24,7 @@ namespace BasisClasses
     "pcavar",
     "pcadiag",
     "pcavtk",
+    "pcaeof",
     "subsamp",
     "snr",
     "samplesz",

--- a/expui/CoefStruct.H
+++ b/expui/CoefStruct.H
@@ -51,6 +51,14 @@ namespace CoefClasses
     //! Read-write access to coefficient data (no copy)
     Eigen::Ref<Eigen::VectorXcd> setCoefs() { return store; }
 
+    //! Set new coefficient data (no copy)
+    void setCoefs(Eigen::VectorXcd& STORE)
+    {
+      if (STORE.size() != store.size())
+	throw std::invalid_argument("CoefStruct::setCoefs: coefficient vector size does not match");
+      store = STORE;
+    }
+
     //! Read-only access to coefficient data (no copy)
     Eigen::Ref<const Eigen::VectorXcd> getCoefs() { return store; }
 

--- a/pyEXP/CoefWrappers.cc
+++ b/pyEXP/CoefWrappers.cc
@@ -724,25 +724,53 @@ void CoefficientClasses(py::module &m) {
         Returns
         -------
         numpy.ndarray
-            complex-valued matrix as a NumPy array of complex values
+            complex-valued matrix as a flattened NumPy array of complex values
 
         See also
         --------
         setCoefs : read-write access to Coefs
         )")
-    .def("setCoefs", &CoefStruct::setCoefs,
+  .def("setCoefs",		// Member function overload
+        static_cast<void (CoefStruct::*)(Eigen::VectorXcd&)>(&CoefStruct::setCoefs),
+        py::arg("mat"),
+        R"(
+        Set the coefficient matrix with the coefficient vector in the same form as returned
+        by getCoefs
+
+        Parameters
+        ----------
+        mat  : numpy.ndarray
+             Flattened array of coefficients
+
+        Returns
+        -------
+        None
+
+        Notes
+        -----
+        The rank data array must match the rank of the CoefStruct.  Use getCoefs to create
+        such an array with the correct rank.
+
+        See also
+        --------
+        getCoefs : read-only access to Coefs
+        )")
+  .def("setCoefs",		// Member function overload
+        static_cast<Eigen::Ref<Eigen::VectorXcd>(CoefStruct::*)()>(&CoefStruct::setCoefs),
         R"(
         Read-write access to the underlying data store
 
         Returns
         -------
         numpy.ndarray
-            complex-valued matrix represented as a NumPy array of complex values
+            reference to a complex-valued matrix represented as a NumPy array of complex
+            values
 
         Notes
         -----
-        Changes made to the data array will be automatically mapped
-        back to the C++ CoefStruct instance.
+        Changes made to the data array will be automatically mapped back to the C++
+        CoefStruct instance.  You may use the setCoefs(array) call to set the data array
+        directly.
 
         See also
         --------


### PR DESCRIPTION
## Summary

This commit overloads `CoefStruct::setCoefs()` to have two call signatures:
1. The original version that returns a reference to the `CoefStruct` data store
2. A void version that takes as input the flattened array of the same form as `CoefStruct::getCoefs()` or `CoefStruct::setCoefs()`; that is, with the signature `void CoefStruct::getCoefs(Eigen::VectorXcd& array)` and sets the underlying data store from array.

This gets around the confusion of needing to set the values of `C` from `C=CoefStruct::setCoefs()` element by element which is a bad use of the numpy API, imho.

## Tests

Tested on the 'custom force' notebook from `pyEXP-examples/Tutorials/Orbits` to confirm that both methods give the same results.  This improves the readability the force function in this notebook very nicely!  I will check that into EXP-code/pyEXP-examples/#13 if we decide to keep this change.

## Notes

This PR adds new minor functionality and, therefore, this addition should not conflict with any current usage pattern and break existing code.