### PR TITLE
Fix accel func

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.25) # Needed for CUDA, MPI, and CTest features
 
 project(
   EXP
-  VERSION "7.8.1"
+  VERSION "7.8.2"
   HOMEPAGE_URL https://github.com/EXP-code/EXP
   LANGUAGES C CXX Fortran)
 

--- a/expui/BasisFactory.H
+++ b/expui/BasisFactory.H
@@ -263,6 +263,8 @@ namespace BasisClasses
     std::vector<std::string> getFieldLabels(void)
     { return getFieldLabels(coordinates); }
 
+    //! Get the basis expansion center
+    std::vector<double> getCenter() { return coefctr; }
   };
   
   using BasisPtr = std::shared_ptr<Basis>;

--- a/expui/BiorthBasis.cc
+++ b/expui/BiorthBasis.cc
@@ -3685,11 +3685,17 @@ namespace BasisClasses
     //
     auto basis = std::get<0>(mod);
 
+    // Get expansion center
+    //
+    auto ctr = basis->getCenter();
+
     // Get fields
     //
     int rows = accel.rows();
     for (int n=0; n<rows; n++) {
-      auto v = basis->getFields(ps(n, 0), ps(n, 1), ps(n, 2));
+      auto v = basis->getFields(ps(n, 0) - ctr[0],
+				ps(n, 1) - ctr[1],
+				ps(n, 2) - ctr[2]);
       // First 6 fields are density and potential, follewed by acceleration
       for (int k=0; k<3; k++) accel(n, k) += v[6+k] - basis->pseudo(k);
     }
@@ -3899,10 +3905,14 @@ namespace BasisClasses
     //
     int numT = floor( (tfinal - tinit)/h );
 
-    // Compute output step
+    // Number of output steps.  Will attempt to find the best stride...
     //
-    nout = std::min<int>(numT, nout);
-    double H = (tfinal - tinit)/nout;
+    int stride = std::ceil(static_cast<double>(numT)/static_cast<double>(nout));
+    if (stride>1) numT = nout * stride;
+
+    // Compute the interval-matching step
+    //
+    h = (tfinal - tinit)/(numT - 1);
 
     // Return data
     //
@@ -3934,9 +3944,11 @@ namespace BasisClasses
       for (int k=0; k<6; k++) ret(n, k, 0) = ps(n, k);
 
     double tnow = tinit;
-    for (int s=1, cnt=1; s<numT; s++) {
+    int s = 0, cnt = 0;
+    while (s < numT) {
+      if (tfinal - tnow < h) h = tfinal - tnow;
       std::tie(tnow, ps) = OneStep(tnow, h, ps, accel, bfe, F);
-      if (tnow >= H*cnt-h*1.0e-8) {
+      if (s++ % stride == 0) {
 	times(cnt) = tnow;
 	for (int n=0; n<rows; n++)
 	  for (int k=0; k<6; k++) ret(n, k, cnt) = ps(n, k);

--- a/expui/BiorthBasis.cc
+++ b/expui/BiorthBasis.cc
@@ -3905,14 +3905,10 @@ namespace BasisClasses
     //
     int numT = floor( (tfinal - tinit)/h );
 
-    // Number of output steps.  Will attempt to find the best stride...
+    // Compute output step
     //
-    int stride = std::ceil(static_cast<double>(numT)/static_cast<double>(nout));
-    if (stride>1) numT = nout * stride;
-
-    // Compute the interval-matching step
-    //
-    h = (tfinal - tinit)/(numT - 1);
+    nout = std::min<int>(numT, nout);
+    double H = (tfinal - tinit)/nout;
 
     // Return data
     //
@@ -3944,11 +3940,9 @@ namespace BasisClasses
       for (int k=0; k<6; k++) ret(n, k, 0) = ps(n, k);
 
     double tnow = tinit;
-    int s = 0, cnt = 0;
-    while (s < numT) {
-      if (tfinal - tnow < h) h = tfinal - tnow;
+    for (int s=1, cnt=1; s<numT; s++) {
       std::tie(tnow, ps) = OneStep(tnow, h, ps, accel, bfe, F);
-      if (s++ % stride == 0) {
+      if (tnow >= H*cnt-h*1.0e-8) {
 	times(cnt) = tnow;
 	for (int n=0; n<rows; n++)
 	  for (int k=0; k<6; k++) ret(n, k, cnt) = ps(n, k);

--- a/expui/CoefStruct.H
+++ b/expui/CoefStruct.H
@@ -73,6 +73,15 @@ namespace CoefClasses
     //! Read-only access to center (no copy)
     std::vector<double> getCenter() { return ctr; }
 
+    //! Set coefficient time (no copy)
+    void setTime(double& STORE)
+    {
+      time = STORE;
+    }
+
+    //! Read-only access to center (no copy)
+    double getTime() { return time; }
+
   };
   
   //! Specialization of CoefStruct for spheres

--- a/expui/CoefStruct.H
+++ b/expui/CoefStruct.H
@@ -62,6 +62,17 @@ namespace CoefClasses
     //! Read-only access to coefficient data (no copy)
     Eigen::Ref<const Eigen::VectorXcd> getCoefs() { return store; }
 
+    //! Set new center data (no copy)
+    void setCenter(std::vector<double>& STORE)
+    {
+      if (STORE.size() != ctr.size())
+        throw std::invalid_argument("CoefStruct::setCenter: center vector size does not match");
+      ctr = STORE;
+    }
+
+    //! Read-only access to center (no copy)
+    std::vector<double> getCenter() { return ctr; }
+
   };
   
   //! Specialization of CoefStruct for spheres

--- a/expui/CoefStruct.H
+++ b/expui/CoefStruct.H
@@ -27,7 +27,7 @@ namespace CoefClasses
     Eigen::VectorXcd store;
     
     //! Center data
-    std::vector<double> ctr;
+    std::vector<double> ctr= {0.0, 0.0, 0.0};
 
     //! Destructor
     virtual ~CoefStruct() {}

--- a/pyEXP/CoefWrappers.cc
+++ b/pyEXP/CoefWrappers.cc
@@ -733,13 +733,13 @@ void CoefficientClasses(py::module &m) {
 
         See also
         --------
-        setCenter : read-write access to the coefficient time
+        setCoefTime : read-write access to the coefficient time
         )")
     .def("setCoefTime",
         static_cast<void (CoefStruct::*)(double&)>(&CoefStruct::setTime),
         py::arg("tval"),
         R"(
-        Set the coefficien time
+        Set the coefficient time
 
         Parameters
         ----------

--- a/pyEXP/CoefWrappers.cc
+++ b/pyEXP/CoefWrappers.cc
@@ -712,11 +712,16 @@ void CoefficientClasses(py::module &m) {
                   str
                       geometry type
                   )")
-    .def_readwrite("time", &CoefStruct::time,
+    .def_readonly("time", &CoefStruct::time,
 		   R"(
                    float
                        data's time stamp
                    )")
+    .def_readonly("center", &CoefStruct::ctr,
+    R"(
+                float
+                    data's center value
+                )") 
     .def("getCoefTime", &CoefStruct::getTime,
         R"(
         Read-only access to the coefficient time

--- a/pyEXP/CoefWrappers.cc
+++ b/pyEXP/CoefWrappers.cc
@@ -717,6 +717,11 @@ void CoefficientClasses(py::module &m) {
                    float
                        data's time stamp
                    )")
+    .def_readwrite("center", &CoefStruct::ctr,
+    R"(
+                array of floats
+                    the expansion center
+                )")
     .def("getCoefs", &CoefStruct::getCoefs,
         R"(
         Read-only access to the underlying data store

--- a/pyEXP/CoefWrappers.cc
+++ b/pyEXP/CoefWrappers.cc
@@ -717,11 +717,46 @@ void CoefficientClasses(py::module &m) {
                    float
                        data's time stamp
                    )")
-    .def_readwrite("center", &CoefStruct::ctr,
+    .def_readonly("center", &CoefStruct::ctr,
     R"(
-                array of floats
-                    the expansion center
-                )")
+        array of floats
+            the expansion center
+        )")
+    .def("getCenter", &CoefStruct::getCenter,
+          R"(
+          Read-only access to the center data
+  
+          Returns
+          -------
+          numpy.ndarray
+              vector of center data
+  
+          See also
+          --------
+          setCenter : read-write access to the center data
+          )")
+    .def("setCenter",
+          static_cast<void (CoefStruct::*)(std::vector<double>&)>(&CoefStruct::setCenter),
+          py::arg("mat"),
+          R"(
+          Set the center vector
+  
+          Parameters
+          ----------
+          mat  : numpy.ndarray
+                center vector
+  
+          Returns
+          -------
+          None
+  
+          Notes
+          -----
+  
+          See also
+          --------
+          getCenter : read-only access to center data
+          )")
     .def("getCoefs", &CoefStruct::getCoefs,
         R"(
         Read-only access to the underlying data store

--- a/pyEXP/CoefWrappers.cc
+++ b/pyEXP/CoefWrappers.cc
@@ -717,12 +717,42 @@ void CoefficientClasses(py::module &m) {
                    float
                        data's time stamp
                    )")
-    .def_readonly("center", &CoefStruct::ctr,
-    R"(
-        array of floats
-            the expansion center
+    .def("getCoefTime", &CoefStruct::getTime,
+        R"(
+        Read-only access to the coefficient time
+
+        Returns
+        -------
+        numpy.ndarray
+            vector of center data
+
+        See also
+        --------
+        setCenter : read-write access to the coefficient time
         )")
-    .def("getCenter", &CoefStruct::getCenter,
+    .def("setCoefTime",
+        static_cast<void (CoefStruct::*)(double&)>(&CoefStruct::setTime),
+        py::arg("tval"),
+        R"(
+        Set the coefficien time
+
+        Parameters
+        ----------
+        tval  : float
+                time value
+
+        Returns
+        -------
+        None
+
+        Notes
+        -----
+
+        See also
+        --------
+        getCenter : read-only access to coefficient time
+        )")
+    .def("getCoefCenter", &CoefStruct::getCenter,
           R"(
           Read-only access to the center data
   
@@ -735,7 +765,7 @@ void CoefficientClasses(py::module &m) {
           --------
           setCenter : read-write access to the center data
           )")
-    .def("setCenter",
+    .def("setCoefCenter",
           static_cast<void (CoefStruct::*)(std::vector<double>&)>(&CoefStruct::setCenter),
           py::arg("mat"),
           R"(


### PR DESCRIPTION
## Summary

This is a draft fix for the expansion center behavior described by @chervs in `IntegrateOrbits()`

## Details

I put in all the infrastructure in `pyEXP` for propagating the expansion center to the `AccelFunc` basis evaluation but then didn't use it for providing translated coordinates for the force evaluation.

This PR is a fix for that.

@M1ssing-N0 : Would you compile this branch and try your failing example? Thanks.