### PR TITLE
Tfinal fix

### DIFF
--- a/expui/BiorthBasis.H
+++ b/expui/BiorthBasis.H
@@ -1189,7 +1189,7 @@ namespace BasisClasses
   std::tuple<Eigen::VectorXd, Eigen::Tensor<float, 3>>
   IntegrateOrbits (double tinit, double tfinal, double h,
 		   Eigen::MatrixXd ps, std::vector<BasisCoef> bfe,
-		   AccelFunctor F, int nout=std::numeric_limits<int>::max());
+		   AccelFunctor F, int nout=0);
 
   using BiorthBasisPtr = std::shared_ptr<BiorthBasis>;
 }

--- a/expui/BiorthBasis.cc
+++ b/expui/BiorthBasis.cc
@@ -3891,7 +3891,6 @@ namespace BasisClasses
     }
 
     if (h < 0.0 and tfinal > tinit) {
-      std::ostringstream sout;
       throw std::runtime_error
 	("BasisClasses::IntegrateOrbits: tfinal must be smaller than tinit "
 	 "when step size is negative");
@@ -3943,7 +3942,7 @@ namespace BasisClasses
       std::cout << "BasisClasses::IntegrateOrbits: memory allocation failed: "
 		<< e.what() << std::endl
 		<< "Your requested number of orbits and time steps requires "
-		<< floor(4.0*rows*6*nout/stride/1e9)+1 << " GB free memory"
+		<< std::floor(4.0*rows*6*nout/1e9)+1 << " GB free memory"
 		<< std::endl;
 
       // Return empty data

--- a/expui/BiorthBasis.cc
+++ b/expui/BiorthBasis.cc
@@ -3899,10 +3899,14 @@ namespace BasisClasses
     //
     int numT = floor( (tfinal - tinit)/h );
 
-    // Compute output step
+    // Number of output steps.  Will attempt to find the best stride...
     //
-    nout = std::min<int>(numT, nout);
-    double H = (tfinal - tinit)/nout;
+    int stride = std::ceil(static_cast<double>(numT)/static_cast<double>(nout));
+    if (stride>1) numT = nout * stride;
+
+    // Compute the interval-matching step
+    //
+    h = (tfinal - tinit)/(numT - 1);
 
     // Return data
     //
@@ -3934,9 +3938,11 @@ namespace BasisClasses
       for (int k=0; k<6; k++) ret(n, k, 0) = ps(n, k);
 
     double tnow = tinit;
-    for (int s=1, cnt=1; s<numT; s++) {
+    int s = 0, cnt = 0;
+    while (s < numT) {
+      if (tfinal - tnow < h) h = tfinal - tnow;
       std::tie(tnow, ps) = OneStep(tnow, h, ps, accel, bfe, F);
-      if (tnow >= H*cnt-h*1.0e-8) {
+      if (s++ % stride == 0) {
 	times(cnt) = tnow;
 	for (int n=0; n<rows; n++)
 	  for (int k=0; k<6; k++) ret(n, k, cnt) = ps(n, k);

--- a/expui/BiorthBasis.cc
+++ b/expui/BiorthBasis.cc
@@ -3914,22 +3914,32 @@ namespace BasisClasses
     
     // Number of steps
     //
-    int numT = std::ceil( (tfinal - tinit)/h );
+    int numT = std::ceil( (tfinal - tinit)/h + 0.5);
 
     // Want both end points in the output at minimum
     //
     numT = std::max(2, numT);
-    nout = std::max(2, nout);
 
-    // Number of output steps.  Compute a stride>1 if nout<numT.
+    // Number of output steps
     //
-    int stride = std::ceil(static_cast<double>(numT)/static_cast<double>(nout));
-    if (stride>1) numT = (nout-1) * stride + 1;
-    else          nout = numT;
+    int stride = 1;		// Default stride
+    if (nout>0) {		// User has specified output count...
+      nout = std::max(2, nout);
+      stride = std::ceil(static_cast<double>(numT)/static_cast<double>(nout));
+      numT = (nout-1) * stride + 1;
+    } else {			// Otherwise, use the default output number
+      nout = numT;		// with the default stride
+    }
 
     // Compute the interval-matching step
     //
     h = (tfinal - tinit)/(numT-1);
+
+    // DEBUG
+    if (false) 
+      std::cout << "BasisClasses::IntegrateOrbits: choosing nout=" << nout
+		<< " numT=" << numT << " h=" << h << " stride=" << stride
+		<< std::endl;
 
     // Return data
     //

--- a/expui/BiorthBasis.cc
+++ b/expui/BiorthBasis.cc
@@ -3885,11 +3885,29 @@ namespace BasisClasses
 
     // Sanity check
     //
+    if (tfinal == tinit) {
+      throw std::runtime_error
+	("BasisClasses::IntegrateOrbits: tinit cannot be equal to tfinal");
+    }
+
+    if (h < 0.0 and tfinal > tinit) {
+      std::ostringstream sout;
+      throw std::runtime_error
+	("BasisClasses::IntegrateOrbits: tfinal must be smaller than tinit "
+	 "when step size is negative");
+    }
+
+    if (h > 0.0 and tfinal < tinit) {
+      throw std::runtime_error
+	("BasisClasses::IntegrateOrbits: tfinal must be larger than "
+	 "tinit when step size is positive");
+    }
+
     if ( (tfinal - tinit)/h >
 	 static_cast<double>(std::numeric_limits<int>::max()) )
       {
-	std::cout << "BasicFactor::IntegrateOrbits: step size is too small or "
-		  << "time interval is too large.\n";
+	std::cout << "BasisClasses::IntegrateOrbits: step size is too small or "
+		  << "time interval is too large." << std::endl;
 	// Return empty data
 	//
 	return {Eigen::VectorXd(), Eigen::Tensor<float, 3>()};
@@ -3897,16 +3915,22 @@ namespace BasisClasses
     
     // Number of steps
     //
-    int numT = floor( (tfinal - tinit)/h );
+    int numT = std::ceil( (tfinal - tinit)/h );
 
-    // Number of output steps.  Will attempt to find the best stride...
+    // Want both end points in the output at minimum
+    //
+    numT = std::max(2, numT);
+    nout = std::max(2, nout);
+
+    // Number of output steps.  Compute a stride>1 if nout<numT.
     //
     int stride = std::ceil(static_cast<double>(numT)/static_cast<double>(nout));
-    if (stride>1) numT = nout * stride;
+    if (stride>1) numT = (nout-1) * stride + 1;
+    else          nout = numT;
 
     // Compute the interval-matching step
     //
-    h = (tfinal - tinit)/(numT - 1);
+    h = (tfinal - tinit)/(numT-1);
 
     // Return data
     //
@@ -3916,10 +3940,10 @@ namespace BasisClasses
       ret.resize(rows, 6, nout);
     }
     catch (const std::bad_alloc& e) {
-      std::cout << "BasicFactor::IntegrateOrbits: memory allocation failed: "
+      std::cout << "BasisClasses::IntegrateOrbits: memory allocation failed: "
 		<< e.what() << std::endl
 		<< "Your requested number of orbits and time steps requires "
-		<< floor(8.0*rows*6*nout/1e9)+1 << " GB free memory"
+		<< floor(4.0*rows*6*nout/stride/1e9)+1 << " GB free memory"
 		<< std::endl;
 
       // Return empty data
@@ -3931,18 +3955,24 @@ namespace BasisClasses
     //
     Eigen::VectorXd times(nout);
     
-    // Do the work
+    // Assign the initial point
     //
     times(0) = tinit;
     for (int n=0; n<rows; n++)
       for (int k=0; k<6; k++) ret(n, k, 0) = ps(n, k);
 
+    // Sign of h
+    int sgn = (0 < h) - (h < 0);
+
+    // Set the counters
     double tnow = tinit;
-    int s = 0, cnt = 0;
-    while (s < numT) {
-      if (tfinal - tnow < h) h = tfinal - tnow;
+    int s = 0, cnt = 1;
+
+    // Do the integration using stride for output
+    while (s++ < numT) {
+      if ( (tfinal - tnow)*sgn < h*sgn) h = tfinal - tnow;
       std::tie(tnow, ps) = OneStep(tnow, h, ps, accel, bfe, F);
-      if (s++ % stride == 0) {
+      if (cnt < nout and s % stride == 0) {
 	times(cnt) = tnow;
 	for (int n=0; n<rows; n++)
 	  for (int k=0; k<6; k++) ret(n, k, cnt) = ps(n, k);
@@ -3950,10 +3980,12 @@ namespace BasisClasses
       }
     }
 
+    // Corrects round off at end point
+    //
     times(nout-1) = tnow;
     for (int n=0; n<rows; n++)
       for (int k=0; k<6; k++) ret(n, k, nout-1) = ps(n, k);
-    
+
     return {times, ret};
   }
 

--- a/pyEXP/BasisWrappers.cc
+++ b/pyEXP/BasisWrappers.cc
@@ -2194,11 +2194,13 @@ void BasisFactoryClasses(py::module &m)
 	R"(
         Compute particle orbits in gravitational field from the bases
 
-        Integrate a list of initial conditions from tinit to tfinal with a
-	step size of h using the list of basis and coefficient pairs. Every
-	step will be included in return unless you provide an explicit
-	value for 'nout', the number of desired output steps.  This will
-	choose the 'nout' points closest to the desired time.
+        Integrate a list of initial conditions from 'tinit' to 'tfinal' with
+	a step size of 'h' using the list of basis and coefficient pairs. The
+        step size will be adjusted to provide uniform sampling.  Every
+	step will be returned unless you provide an explicit value for 'nout',
+        the number of desired output steps.  In this case, the code will
+        choose new set step size equal or smaller to the supplied step size
+        with a stride to provide exactly 'nout' output times.
 
         Parameters
         ----------
@@ -2216,7 +2218,7 @@ void BasisFactoryClasses(py::module &m)
         func : AccelFunctor
             the force function
         nout : int 
-            the number of output intervals if (tfinal - tinit) / h > nout
+            the number of output points, if specified
 
         Returns
         -------
@@ -2225,5 +2227,5 @@ void BasisFactoryClasses(py::module &m)
         )",
 	py::arg("tinit"), py::arg("tfinal"), py::arg("h"),
 	py::arg("ps"), py::arg("basiscoef"), py::arg("func"),
-	py::arg("nout")=std::numeric_limits<int>::max());
+	py::arg("nout")=0);
 }

--- a/pyEXP/BasisWrappers.cc
+++ b/pyEXP/BasisWrappers.cc
@@ -2198,7 +2198,7 @@ void BasisFactoryClasses(py::module &m)
 	step size of h using the list of basis and coefficient pairs. Every
 	step will be included in return unless you provide an explicit
 	value for 'nout', the number of desired output steps.  This will
-	choose the 'nout' points closed to the desired time.
+	choose the 'nout' points closest to the desired time.
 
         Parameters
         ----------
@@ -2216,7 +2216,7 @@ void BasisFactoryClasses(py::module &m)
         func : AccelFunctor
             the force function
         nout : int 
-            the number of output intervals
+            the number of output intervals if (tfinal - tinit) / h > nout
 
         Returns
         -------


### PR DESCRIPTION
# Summary

This is a fix for the PR in #99: `IntegrateOrbits()` returning time series that **DO NOT** include the final time point.

# Details

The patch condenses the previous patch from PR #99 to only changes relevant to the `tfinal` issue.  Specifically, the features are:
- Checks on the time interval and sign of the step size for consistency, as suggested by @M1ssing-N0
- Bounds checking ensures that the initial and final times provided by the user are in the returned orbit
- By default, the step size is decreased slightly, if necessary, to achieve an even multiple of steps in the provided interval
- If `nout` is provided, the algorithm computes a new step size that allows a uniform integral stride of some step size equal or smaller than the provided step size while providing exactly `nout` points in the return.