### PR TITLE
Expose pseudo-force interface using pybind11 [WIP]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.25) # Needed for CUDA, MPI, and CTest features
 
 project(
   EXP
-  VERSION "7.8.1"
+  VERSION "7.8.2"
   HOMEPAGE_URL https://github.com/EXP-code/EXP
   LANGUAGES C CXX Fortran)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.25) # Needed for CUDA, MPI, and CTest features
 
 project(
   EXP
-  VERSION "7.8.2"
+  VERSION "7.8.3"
   HOMEPAGE_URL https://github.com/EXP-code/EXP
   LANGUAGES C CXX Fortran)
 

--- a/expui/BasisFactory.H
+++ b/expui/BasisFactory.H
@@ -137,6 +137,7 @@ namespace BasisClasses
     Eigen::Vector3d currentAccel(double time);
 
   public:
+
     //! The current pseudo acceleration
     Eigen::Vector3d pseudo {0, 0, 0};
 
@@ -261,6 +262,13 @@ namespace BasisClasses
 
     //! Returns true if non-intertial forces are active
     bool usingNonInertial() { return Naccel > 0; }
+
+    //! Reset to inertial coordinates
+    void setInertial()
+    {
+      Naccel = 0;
+      pseudo = {0, 0, 0};
+    }
 
     //! Get the field label vector
     std::vector<std::string> getFieldLabels(void)

--- a/expui/BasisFactory.H
+++ b/expui/BasisFactory.H
@@ -249,8 +249,8 @@ namespace BasisClasses
 
     //@{
     //! Initialize non-inertial forces
-    void setNonInertial(const Eigen::VectorXd& x, const Eigen::MatrixXd& pos);
-    void setNonInertial(const std::string& orient);
+    void setNonInertial(int Naccel, const Eigen::VectorXd& x, const Eigen::MatrixXd& pos);
+    void setNonInertial(int Naccel, const std::string& orient);
     //@}
 
     //! Set the current pseudo acceleration

--- a/expui/BasisFactory.H
+++ b/expui/BasisFactory.H
@@ -260,7 +260,7 @@ namespace BasisClasses
       if (Naccel > 0) pseudo = currentAccel(time);
     }
 
-    //! Returns true if non-intertial forces are active
+    //! Returns true if non-inertial forces are active
     bool usingNonInertial() { return Naccel > 0; }
 
     //! Reset to inertial coordinates

--- a/expui/BasisFactory.H
+++ b/expui/BasisFactory.H
@@ -263,6 +263,8 @@ namespace BasisClasses
     std::vector<std::string> getFieldLabels(void)
     { return getFieldLabels(coordinates); }
 
+    //! Get the basis expansion center
+    std::vector<double> getCenter() { return coefctr; }
   };
   
   using BasisPtr = std::shared_ptr<Basis>;

--- a/expui/BasisFactory.H
+++ b/expui/BasisFactory.H
@@ -249,8 +249,8 @@ namespace BasisClasses
 
     //@{
     //! Initialize non-inertial forces
-    void setNonInertial(int N, Eigen::VectorXd& x, Eigen::MatrixXd& pos);
-    void setNonInertial(int N, const std::string& orient);
+    void setNonInertial(const Eigen::VectorXd& x, const Eigen::MatrixXd& pos);
+    void setNonInertial(const std::string& orient);
     //@}
 
     //! Set the current pseudo acceleration
@@ -258,6 +258,9 @@ namespace BasisClasses
     {
       if (Naccel > 0) pseudo = currentAccel(time);
     }
+
+    //! Returns true if non-intertial forces are active
+    bool usingNonInertial() { return Naccel > 0; }
 
     //! Get the field label vector
     std::vector<std::string> getFieldLabels(void)

--- a/expui/BasisFactory.cc
+++ b/expui/BasisFactory.cc
@@ -283,7 +283,7 @@ namespace BasisClasses
     return makeFromArray(time);
   }
 
-  void Basis::setNonInertial(const Eigen::VectorXd& t, const Eigen::MatrixXd& pos)
+  void Basis::setNonInertial(int N, const Eigen::VectorXd& t, const Eigen::MatrixXd& pos)
   {
     // Sanity checks
     if (t.size() < 1)
@@ -293,12 +293,12 @@ namespace BasisClasses
       throw std::runtime_error("Basis::setNonInertial: size mismatch in time and position arrays");
 
     // Set the data
-    Naccel  = t.size();
+    Naccel  = N;
     t_accel = t;
     p_accel = pos;
   }
 
-  void Basis::setNonInertial(const std::string& orient)
+  void Basis::setNonInertial(int N, const std::string& orient)
   {
     std::ifstream in(orient);
 
@@ -345,7 +345,7 @@ namespace BasisClasses
     }
 
     // Repack data
-    Naccel = times.size();
+    Naccel = N;
     t_accel.resize(times.size());
     p_accel.resize(times.size(), 3);
     for (int i=0; i<times.size(); i++) {

--- a/expui/BasisFactory.cc
+++ b/expui/BasisFactory.cc
@@ -283,14 +283,22 @@ namespace BasisClasses
     return makeFromArray(time);
   }
 
-  void Basis::setNonInertial(int N, Eigen::VectorXd& t, Eigen::MatrixXd& pos)
+  void Basis::setNonInertial(const Eigen::VectorXd& t, const Eigen::MatrixXd& pos)
   {
-    Naccel  = N;
+    // Sanity checks
+    if (t.size() < 1)
+      throw std::runtime_error("Basis: setNonInertial: no times in time array");
+
+    if (t.size() != pos.rows())
+      throw std::runtime_error("Basis::setNonInertial: size mismatch in time and position arrays");
+
+    // Set the data
+    Naccel  = t.size();
     t_accel = t;
     p_accel = pos;
   }
 
-  void Basis::setNonInertial(int N, const std::string& orient)
+  void Basis::setNonInertial(const std::string& orient)
   {
     std::ifstream in(orient);
 
@@ -337,7 +345,7 @@ namespace BasisClasses
     }
 
     // Repack data
-    Naccel = N;
+    Naccel = times.size();
     t_accel.resize(times.size());
     p_accel.resize(times.size(), 3);
     for (int i=0; i<times.size(); i++) {

--- a/expui/BasisFactory.cc
+++ b/expui/BasisFactory.cc
@@ -368,7 +368,10 @@ namespace BasisClasses
     else {
       int imin = 0;
       int imax = std::lower_bound(t_accel.data(), t_accel.data()+t_accel.size(), time) - t_accel.data();
-      if (imax > Naccel) imin = imax - Naccel;
+
+      // Get a range around the current time of approx size Naccel
+      imax = std::min<int>(t_accel.size()-1, imax + Naccel/2);
+      imin = std::max<int>(imax - Naccel, 0);
 
       int num = imax - imin + 1;
       Eigen::VectorXd t(num);

--- a/expui/BiorthBasis.cc
+++ b/expui/BiorthBasis.cc
@@ -3687,8 +3687,8 @@ namespace BasisClasses
 
     // Get expansion center
     //
-    std::vector<double> ctr {0, 0, 0};
-    if (basis->usingNonInertial()) ctr = basis->getCenter();
+    auto ctr = basis->getCenter();
+    if (basis->usingNonInertial()) ctr = {0, 0, 0};
 
     // Get fields
     //

--- a/expui/BiorthBasis.cc
+++ b/expui/BiorthBasis.cc
@@ -2486,8 +2486,7 @@ namespace BasisClasses
     CoefClasses::CylStruct* cf = dynamic_cast<CoefClasses::CylStruct*>(coef.get());
     auto & cc = *cf->coefs;
 
-    // Cache the cuurent coefficient structure
-    //
+    // Cache the current coefficient structure
     coefret = coef;
 
     // Assign internal coefficient table (doubles) from the complex struct

--- a/expui/BiorthBasis.cc
+++ b/expui/BiorthBasis.cc
@@ -3685,11 +3685,17 @@ namespace BasisClasses
     //
     auto basis = std::get<0>(mod);
 
+    // Get expansion center
+    //
+    auto ctr = basis->getCenter();
+
     // Get fields
     //
     int rows = accel.rows();
     for (int n=0; n<rows; n++) {
-      auto v = basis->getFields(ps(n, 0), ps(n, 1), ps(n, 2));
+      auto v = basis->getFields(ps(n, 0) - ctr[0],
+				ps(n, 1) - ctr[1],
+				ps(n, 2) - ctr[2]);
       // First 6 fields are density and potential, follewed by acceleration
       for (int k=0; k<3; k++) accel(n, k) += v[6+k] - basis->pseudo(k);
     }

--- a/expui/BiorthBasis.cc
+++ b/expui/BiorthBasis.cc
@@ -3727,13 +3727,12 @@ namespace BasisClasses
       throw std::runtime_error(sout.str());
     }
     
-    auto it1 = std::lower_bound(times.begin(), times.end(), t);
-    auto it2 = it1 + 1;
+    auto it2 = std::lower_bound(times.begin(), times.end(), t);
+    auto it1 = it2;
 
-    if (it2 == times.end()) {
-      it2--;
-      it1 = it2 - 1;
-    }
+    if (it2 == times.end()) throw std::runtime_error("Basis::AllTimeAccel::evalcoefs: time t=" + std::to_string(t) + " out of bounds");
+    else if (it2 == times.begin()) it2++;
+    else it1--;
 
     double a = (*it2 - t)/(*it2 - *it1);
     double b = (t - *it1)/(*it2 - *it1);
@@ -3791,13 +3790,12 @@ namespace BasisClasses
 	throw std::runtime_error(sout.str());
       }
       
-      auto it1 = std::lower_bound(times.begin(), times.end(), t);
-      auto it2 = it1 + 1;
-      
-      if (it2 == times.end()) {
-	it2--;
-	it1 = it2 - 1;
-      }
+      auto it2 = std::lower_bound(times.begin(), times.end(), t);
+      auto it1 = it2;
+
+      if (it2 == times.end()) throw std::runtime_error("Basis::AllTimeAccel::evalcoefs: time t=" + std::to_string(t) + " out of bounds");
+      else if (it2 == times.begin()) it2++;
+      else it1--;
       
       double a = (*it2 - t)/(*it2 - *it1);
       double b = (t - *it1)/(*it2 - *it1);

--- a/expui/BiorthBasis.cc
+++ b/expui/BiorthBasis.cc
@@ -3697,7 +3697,7 @@ namespace BasisClasses
       auto v = basis->getFields(ps(n, 0) - ctr[0],
 				ps(n, 1) - ctr[1],
 				ps(n, 2) - ctr[2]);
-      // First 6 fields are density and potential, follewed by acceleration
+      // First 6 fields are density and potential, followed by acceleration
       for (int k=0; k<3; k++) accel(n, k) += v[6+k] - basis->pseudo(k);
     }
 

--- a/expui/BiorthBasis.cc
+++ b/expui/BiorthBasis.cc
@@ -3687,7 +3687,8 @@ namespace BasisClasses
 
     // Get expansion center
     //
-    auto ctr = basis->getCenter();
+    std::vector<double> ctr {0, 0, 0};
+    if (basis->usingNonInertial()) ctr = basis->getCenter();
 
     // Get fields
     //

--- a/expui/BiorthBasis.cc
+++ b/expui/BiorthBasis.cc
@@ -396,6 +396,10 @@ namespace BasisClasses
     
     CoefClasses::SphStruct* cf = dynamic_cast<CoefClasses::SphStruct*>(coef.get());
 
+    // Cache the current coefficient structure
+    //
+    coefret = coef;
+
     // Assign internal coefficient table (doubles) from the complex struct
     //
     for (int l=0, L0=0, L1=0; l<=lmax; l++) {
@@ -1474,6 +1478,10 @@ namespace BasisClasses
 
     CoefClasses::CylStruct* cf = dynamic_cast<CoefClasses::CylStruct*>(coef.get());
 
+    // Cache the current coefficient structure
+    //
+    coefret = coef;
+
     for (int m=0; m<=mmax; m++) { // Set to zero on m=0 call only--------+
       sl->set_coefs(m, (*cf->coefs).row(m).real(), (*cf->coefs).row(m).imag(), m==0);
     }
@@ -1770,6 +1778,10 @@ namespace BasisClasses
     
     CoefClasses::CylStruct* cf = dynamic_cast<CoefClasses::CylStruct*>(coef.get());
     auto & cc = *cf->coefs;
+
+    // Cache the current coefficient structure
+    //
+    coefret = coef;
 
     // Assign internal coefficient table (doubles) from the complex struct
     //
@@ -2474,6 +2486,10 @@ namespace BasisClasses
     CoefClasses::CylStruct* cf = dynamic_cast<CoefClasses::CylStruct*>(coef.get());
     auto & cc = *cf->coefs;
 
+    // Cache the cuurent coefficient structure
+    //
+    coefret = coef;
+
     // Assign internal coefficient table (doubles) from the complex struct
     //
     for (int m=0, m0=0; m<=mmax; m++) {
@@ -2873,6 +2889,10 @@ namespace BasisClasses
     
     auto cf = dynamic_cast<CoefClasses::SlabStruct*>(coef.get());
     expcoef = *cf->coefs;
+
+    // Cache the current coefficient structure
+    //
+    coefret = coef;
 
     coefctr = {0.0, 0.0, 0.0};
   }
@@ -3306,6 +3326,10 @@ namespace BasisClasses
     auto cf = dynamic_cast<CoefClasses::CubeStruct*>(coef.get());
     expcoef = *cf->coefs;
 
+    // Cache the cuurent coefficient structure
+    //
+    coefret = coef;
+
     coefctr = {0.0, 0.0, 0.0};
   }
 
@@ -3699,6 +3723,30 @@ namespace BasisClasses
 				ps(n, 2) - ctr[2]);
       // First 6 fields are density and potential, followed by acceleration
       for (int k=0; k<3; k++) accel(n, k) += v[6+k] - basis->pseudo(k);
+    }
+
+    // true for deep debugging
+    //  |
+    //  v
+    if (true and basis->usingNonInertial()) {
+
+      auto coefs = basis->getCoefficients();
+      auto time  = coefs->time;
+      auto ctr   = coefs->ctr;
+
+      std::ofstream tmp;
+      if (time <= 0.0) tmp.open("pseudo.dat");
+      else             tmp.open("pseudo.dat", ios::app);
+
+      if (tmp)
+	tmp << std::setw(16) << std::setprecision(5) << time
+	    << std::setw(16) << std::setprecision(5) << ctr[0]
+	    << std::setw(16) << std::setprecision(5) << ctr[1]
+	    << std::setw(16) << std::setprecision(5) << ctr[2]
+	    << std::setw(16) << std::setprecision(5) << basis->pseudo(0)
+	    << std::setw(16) << std::setprecision(5) << basis->pseudo(1)
+	    << std::setw(16) << std::setprecision(5) << basis->pseudo(2)
+	    << std::endl;
     }
 
     return accel;

--- a/expui/CoefStruct.H
+++ b/expui/CoefStruct.H
@@ -27,7 +27,7 @@ namespace CoefClasses
     Eigen::VectorXcd store;
     
     //! Center data
-    std::vector<double> ctr;
+    std::vector<double> ctr= {0.0, 0.0, 0.0};
 
     //! Destructor
     virtual ~CoefStruct() {}
@@ -61,6 +61,26 @@ namespace CoefClasses
 
     //! Read-only access to coefficient data (no copy)
     Eigen::Ref<const Eigen::VectorXcd> getCoefs() { return store; }
+
+    //! Set new center data (no copy)
+    void setCenter(std::vector<double>& STORE)
+    {
+      if (STORE.size() != ctr.size())
+        throw std::invalid_argument("CoefStruct::setCenter: center vector size does not match");
+      ctr = STORE;
+    }
+
+    //! Read-only access to center (no copy)
+    std::vector<double> getCenter() { return ctr; }
+
+    //! Set coefficient time (no copy)
+    void setTime(double& STORE)
+    {
+      time = STORE;
+    }
+
+    //! Read-only access to center (no copy)
+    double getTime() { return time; }
 
   };
   

--- a/pyEXP/BasisWrappers.cc
+++ b/pyEXP/BasisWrappers.cc
@@ -959,6 +959,24 @@ void BasisFactoryClasses(py::module &m)
            list of basis function labels
          )"
 	 )
+    .def("setInertial", &BasisClasses::Basis::setInertial,
+	 R"(
+         Reset to inertial coordinates
+
+         Parameters
+         ----------
+         None
+
+         Returns
+         -------
+         None
+
+         See also
+         --------
+         setNonInertial : set non-inertial data
+         setNonInertialAccel : set the non-inertial acceration
+         )"
+	 )
     .def("setNonInertial",
 	 [](BasisClasses::Basis& A,
 	    int N, const Eigen::VectorXd& times, const Eigen::MatrixXd& pos) {

--- a/pyEXP/BasisWrappers.cc
+++ b/pyEXP/BasisWrappers.cc
@@ -974,7 +974,7 @@ void BasisFactoryClasses(py::module &m)
          See also
          --------
          setNonInertial : set non-inertial data
-         setNonInertialAccel : set the non-inertial acceration
+         setNonInertialAccel : set the non-inertial acceleration
          )"
 	 )
     .def("setNonInertial",

--- a/pyEXP/BasisWrappers.cc
+++ b/pyEXP/BasisWrappers.cc
@@ -205,7 +205,7 @@ void BasisFactoryClasses(py::module &m)
     Each component of a multiple component simulation may have its own expansion
     center. Orbit integration in the frame of reference of the expansion is
     accomplished by defining a moving frame of reference using the setNonInertial()
-    call with either an array of times (N) and center positions (as an Nx3 array)
+    call with either an array of n times and center positions (as an nx3 array)
     or by initializing with an EXP orient file.
 
     We provide a member function, setNonInertialAccel(t), to estimate the frame
@@ -961,8 +961,8 @@ void BasisFactoryClasses(py::module &m)
 	 )
     .def("setNonInertial",
 	 [](BasisClasses::Basis& A,
-	    const Eigen::VectorXd& times, const Eigen::MatrixXd& pos) {
-	   A.setNonInertial(times, pos);
+	    int N, const Eigen::VectorXd& times, const Eigen::MatrixXd& pos) {
+	   A.setNonInertial(N, times, pos);
 	 },
 	 R"(
          Initialize for pseudo-force computation with a time series of positions
@@ -971,6 +971,8 @@ void BasisFactoryClasses(py::module &m)
 
          Parameters
          ----------
+         N : int
+           number of previous positions to use for quadratic fit
          times : list or numpy.ndarray
            list of time points
          pos : numpy.ndarray
@@ -985,12 +987,12 @@ void BasisFactoryClasses(py::module &m)
          setNonInertial : set non-inertial data from an Orient file
          setNonInertialAccel : set the non-inertial acceration
          )",
-	 py::arg("times"), py::arg("pos")
+	 py::arg("N"), py::arg("times"), py::arg("pos")
          )
     .def("setNonInertial",
-	 [](BasisClasses::Basis& A, const std::string orient)
+	 [](BasisClasses::Basis& A, int N, const std::string orient)
 	 {
-	   A.setNonInertial(orient);
+	   A.setNonInertial(N, orient);
 	 },
 	 R"(
          Initialize for pseudo-force computation with a time series of positions
@@ -998,6 +1000,8 @@ void BasisFactoryClasses(py::module &m)
 
          Parameters
          ----------
+         N : int
+           number of previous positions to use for quadratic fit
          orient : str
            name of the orient file
 
@@ -1010,7 +1014,7 @@ void BasisFactoryClasses(py::module &m)
          setNonInertial : set non-inertial data from a time series of values
          setNonInertialAccel : set the non-inertial acceration
          )",
-	 py::arg("orient")
+	 py::arg("N"), py::arg("orient")
          )
     .def("setNonInertialAccel", &BasisClasses::Basis::setNonInertialAccel,
 	 R"(

--- a/pyEXP/CoefWrappers.cc
+++ b/pyEXP/CoefWrappers.cc
@@ -712,11 +712,86 @@ void CoefficientClasses(py::module &m) {
                   str
                       geometry type
                   )")
-    .def_readwrite("time", &CoefStruct::time,
+    .def_readonly("time", &CoefStruct::time,
 		   R"(
                    float
                        data's time stamp
                    )")
+    .def_readonly("center", &CoefStruct::ctr,
+    R"(
+                float
+                    data's center value
+                )") 
+    .def("getCoefTime", &CoefStruct::getTime,
+        R"(
+        Read-only access to the coefficient time
+
+        Returns
+        -------
+        numpy.ndarray
+            vector of center data
+
+        See also
+        --------
+        setCoefTime : read-write access to the coefficient time
+        )")
+    .def("setCoefTime",
+        static_cast<void (CoefStruct::*)(double&)>(&CoefStruct::setTime),
+        py::arg("tval"),
+        R"(
+        Set the coefficient time
+
+        Parameters
+        ----------
+        tval  : float
+                time value
+
+        Returns
+        -------
+        None
+
+        Notes
+        -----
+
+        See also
+        --------
+        getCenter : read-only access to coefficient time
+        )")
+    .def("getCoefCenter", &CoefStruct::getCenter,
+          R"(
+          Read-only access to the center data
+  
+          Returns
+          -------
+          numpy.ndarray
+              vector of center data
+  
+          See also
+          --------
+          setCenter : read-write access to the center data
+          )")
+    .def("setCoefCenter",
+          static_cast<void (CoefStruct::*)(std::vector<double>&)>(&CoefStruct::setCenter),
+          py::arg("mat"),
+          R"(
+          Set the center vector
+  
+          Parameters
+          ----------
+          mat  : numpy.ndarray
+                center vector
+  
+          Returns
+          -------
+          None
+  
+          Notes
+          -----
+  
+          See also
+          --------
+          getCenter : read-only access to center data
+          )")
     .def("getCoefs", &CoefStruct::getCoefs,
         R"(
         Read-only access to the underlying data store

--- a/pyEXP/UtilWrappers.cc
+++ b/pyEXP/UtilWrappers.cc
@@ -155,4 +155,22 @@ void UtilityClasses(py::module &m) {
         Report on the version and git commit.  
 
         This is the same version information reported by the EXP N-body code.)");
+  m.def("Version",
+    []() {
+      std::string version_str = VERSION;
+      std::istringstream iss(version_str);
+      std::string token;
+      int parts[3] = {0, 0, 0};
+      int i = 0;
+
+      while (std::getline(iss, token, '.') && i < 3) {
+          parts[i++] = std::stoi(token);
+      }
+
+      return std::make_tuple(parts[0], parts[1], parts[2]);
+  },
+    R"(
+          Return the version.  
+  
+          This is the same version information reported by the EXP N-body code.)");
 }


### PR DESCRIPTION
## New pseudo-force features
Work so far:
1. Wrapped `setNonInertial` and `setNonInertialAccel` for setting and requesting evaluation of a pseudoforce
2. Simplified the call structure of `setNonInertial`.  There are two variants: (1) passing a times and centers as arrays; and (2) passing an EXP `Orient` file.
3. I added a boolean member function to `Basis::usingNonIntertial()`  to tell client classes whether to use inertial or expansion frame coordinates.

## Comments
Code compiles but none of this has been tested.
