### PR TITLE
Detrending flags

### DIFF
--- a/expui/BiorthBasis.H
+++ b/expui/BiorthBasis.H
@@ -729,6 +729,7 @@ namespace BasisClasses
     int used;
     
     std::string cachename;
+    bool oldcache = false;
     
     using matT = std::vector<Eigen::MatrixXd>;
     using vecT = std::vector<Eigen::VectorXd>;

--- a/expui/BiorthBasis.cc
+++ b/expui/BiorthBasis.cc
@@ -890,6 +890,7 @@ namespace BasisClasses
     "npca0",
     "nvtk",
     "cachename",
+    "oldcache",
     "eof_file",
     "override",
     "samplesz",
@@ -1061,6 +1062,7 @@ namespace BasisClasses
     ncylodd     = 9;
     ncylr       = 2000;
     cachename   = ".eof_cache_file";
+    oldcache    = false;
     Ignore      = false;
     deproject   = false;
     
@@ -1139,6 +1141,7 @@ namespace BasisClasses
       if (conf["ncylodd"   ])    ncylodd  = conf["ncylodd"   ].as<int>();
       if (conf["cachename" ])  cachename  = conf["cachename" ].as<std::string>();
       if (conf["eof_file"  ])  cachename  = conf["eof_file"  ].as<std::string>();
+      if (conf["oldcache"  ])   oldcache  = conf["oldcache"  ].as<bool>();
       if (conf["rnum"      ])       rnum  = conf["rnum"      ].as<int>();
       if (conf["pnum"      ])       pnum  = conf["pnum"      ].as<int>();
       if (conf["tnum"      ])       tnum  = conf["tnum"      ].as<int>();
@@ -1238,6 +1241,11 @@ namespace BasisClasses
     if (mlim>=0)  sl->set_mlim(mlim);
     if (EVEN_M)   sl->setEven(EVEN_M);
       
+    // Cache override for old Eigen cache
+    //
+    if (oldcache) sl->AllowOldCache();
+    
+
     // Attempt to read EOF cache
     //
     if (sl->read_cache() == 0) {

--- a/expui/expMSSA.H
+++ b/expui/expMSSA.H
@@ -84,8 +84,8 @@ namespace MSSA
     //! Number of components in the reconstruction
     int ncomp;
 
-    //! Normalization values
-    double totVar, totPow;
+    //! Normalization options
+    bool totVar, totPow;
 
     //! Toggle for detrending
     bool useMean;

--- a/expui/expMSSA.cc
+++ b/expui/expMSSA.cc
@@ -1522,8 +1522,8 @@ namespace MSSA {
 	HighFive::Group recon = file.createGroup("reconstruction");
 
 	recon.createAttribute<int>   ("ncomp",  HighFive::DataSpace::From(ncomp) ).write(ncomp);
-	recon.createAttribute<double>("totVar", HighFive::DataSpace::From(totVar)).write(totVar);
-	recon.createAttribute<double>("totPow", HighFive::DataSpace::From(totVar)).write(totPow);
+	recon.createAttribute<bool>("totVar", HighFive::DataSpace::From(totVar)).write(totVar);
+	recon.createAttribute<bool>("totPow", HighFive::DataSpace::From(totVar)).write(totPow);
 
 	for (int n=0; n<keylist.size(); n++) {
 	  std::ostringstream scnt;
@@ -1961,13 +1961,22 @@ namespace MSSA {
     // Detrending style (totVar and totPow are only useful, so far, for
     // noise computation)
     //
-    if (params["totVar"])
-      type = TrendType::totVar;
-    else if (params["totPow"])
-      type = TrendType::totPow;
-    else
-      type = TrendType::perChannel;
+    if (params["totVar"]) totVar = params["totVar"].as<bool>();
+    if (params["totPow"]) totPow = params["totPow"].as<bool>();
 
+    if (totPow==true) {
+      if (totVar==true) {
+        std::cerr << "expMSSA: both totVar and totPow are set to true."
+                  << "Using totPow." << std::endl;
+        totVar = false;
+      }
+      type = TrendType::totPow;
+    } else if (totVar==true) {
+      type = TrendType::totVar;
+    } else {
+      // if nothing set go default
+      type = TrendType::perChannel;
+    }
 
     // Set the SVD strategy for mSSA
     //

--- a/exputil/EmpCylSL.cc
+++ b/exputil/EmpCylSL.cc
@@ -264,7 +264,8 @@ EmpCylSL::EmpCylSL(int mlim, std::string cachename)
       if (ver.compare(Version))
 	throw std::runtime_error("EmpCylSL: version mismatch");
     } else {
-      throw std::runtime_error("EmpCylSL: outdated cache");
+      if (not allow_old_cache)
+	throw std::runtime_error("EmpCylSL: outdated cache");
     }
 
     NMAX    = getH5<int>("nmaxfid", file);
@@ -7388,6 +7389,13 @@ bool EmpCylSL::ReadH5Cache()
 	rforceC[m][n] = order.getDataSet("rforceC").read<Eigen::MatrixXd>();
 	zforceC[m][n] = order.getDataSet("zforceC").read<Eigen::MatrixXd>();
 	densC  [m][n] = order.getDataSet("densC")  .read<Eigen::MatrixXd>();
+
+	if (allow_old_cache) {
+	  potC   [m][n] = potC   [m][n].transpose();
+	  rforceC[m][n] = rforceC[m][n].transpose();
+	  zforceC[m][n] = zforceC[m][n].transpose();
+	  densC  [m][n] = densC  [m][n].transpose();
+	}
       }
     }
 
@@ -7411,6 +7419,13 @@ bool EmpCylSL::ReadH5Cache()
 	rforceS[m][n] = order.getDataSet("rforceS").read<Eigen::MatrixXd>();
 	zforceS[m][n] = order.getDataSet("zforceS").read<Eigen::MatrixXd>();
 	densS  [m][n] = order.getDataSet("densS")  .read<Eigen::MatrixXd>();
+
+	if (allow_old_cache) {
+	  potC   [m][n] = potC   [m][n].transpose();
+	  rforceC[m][n] = rforceC[m][n].transpose();
+	  zforceC[m][n] = zforceC[m][n].transpose();
+	  densC  [m][n] = densC  [m][n].transpose();
+	}
       }
     }
 

--- a/exputil/EmpCylSL.cc
+++ b/exputil/EmpCylSL.cc
@@ -267,7 +267,7 @@ EmpCylSL::EmpCylSL(int mlim, std::string cachename)
 	if (myid==0)
 	  std::cout << "---- EmpCylSL::ReadH5Cache: "
 		    << "using a workaround for a HighFive HDF5 wrapper bug. "
-        << "this workaround will be removed in EXP 7.9.0. "
+                    << "this workaround will be removed in EXP 7.9.0. "
 		    << "Please consider rebuilding your cache if possible!"
 		    << std::endl;
       }

--- a/exputil/EmpCylSL.cc
+++ b/exputil/EmpCylSL.cc
@@ -65,7 +65,6 @@ double   EmpCylSL::RMIN            = 0.001;
 double   EmpCylSL::RMAX            = 20.0;
 double   EmpCylSL::HFAC            = 0.2;
 double   EmpCylSL::PPOW            = 4.0;
-bool     EmpCylSL::NewCache        = true;
 bool     EmpCylSL::NewCoefs        = true;
  
 

--- a/exputil/EmpCylSL.cc
+++ b/exputil/EmpCylSL.cc
@@ -267,6 +267,7 @@ EmpCylSL::EmpCylSL(int mlim, std::string cachename)
 	if (myid==0)
 	  std::cout << "---- EmpCylSL::ReadH5Cache: "
 		    << "using a workaround for a HighFive HDF5 wrapper bug. "
+        << "this workaround will be removed in EXP 7.9.0. "
 		    << "Please consider rebuilding your cache if possible!"
 		    << std::endl;
       }
@@ -7333,6 +7334,7 @@ bool EmpCylSL::ReadH5Cache()
 	if (myid==0)
 	  std::cout << "---- EmpCylSL::ReadH5Cache: "
 		    << "using a workaround for a HighFive HDF5 wrapper bug. "
+        << "this workaround will be removed in EXP 7.9.0. "
 		    << "Please consider rebuilding your cache if possible!" << std::endl;
       }
       else {

--- a/exputil/EmpCylSL.cc
+++ b/exputil/EmpCylSL.cc
@@ -263,8 +263,14 @@ EmpCylSL::EmpCylSL(int mlim, std::string cachename)
       if (ver.compare(Version))
 	throw std::runtime_error("EmpCylSL: version mismatch");
     } else {
-      if (not allow_old_cache)
-	throw std::runtime_error("EmpCylSL: outdated cache");
+      if (allow_old_cache) {
+	if (myid==0)
+	  std::cout << "---- EmpCylSL::ReadH5Cache: "
+		    << "using a workaround for a HighFive HDF5 wrapper bug. "
+		    << "Please consider rebuilding your cache if possible!"
+		    << std::endl;
+      }
+      else throw std::runtime_error("EmpCylSL: outdated cache");
     }
 
     NMAX    = getH5<int>("nmaxfid", file);
@@ -7323,7 +7329,13 @@ bool EmpCylSL::ReadH5Cache()
     if (file.hasAttribute("Version")) {
       if (not checkStr(Version, "Version"))  return false;
     } else {
-      if (not allow_old_cache) {
+      if (allow_old_cache) {
+	if (myid==0)
+	  std::cout << "---- EmpCylSL::ReadH5Cache: "
+		    << "using a workaround for a HighFive HDF5 wrapper bug. "
+		    << "Please consider rebuilding your cache if possible!" << std::endl;
+      }
+      else {
 	if (myid==0)
 	  std::cout << "---- EmpCylSL::ReadH5Cache: "
 		    << "recomputing cache for HighFive API change"

--- a/include/EmpCylSL.H
+++ b/include/EmpCylSL.H
@@ -451,9 +451,6 @@ public:
   //! Power exponent for EOF conditioning density function
   static double PPOW;
 
-  //! Use YAML header in cache file
-  static bool NewCache;
-
   //! Use YAML header in coefficient file
   static bool NewCoefs;
 

--- a/include/EmpCylSL.H
+++ b/include/EmpCylSL.H
@@ -340,6 +340,10 @@ protected:
   //! MPI is active
   bool use_mpi;
 
+  //! Allow older cache files with the Eigen3 row-major bug to be read
+  //! with the new Eigen3 API
+  bool allow_old_cache = false;
+
 public:
 
   /*! Enum listing the possible selection algorithms for coefficient
@@ -807,6 +811,11 @@ public:
   //! map/dictionary
   static std::map<std::string, std::string>
   cacheInfo(const std::string& cachefile, bool verbose=true);
+
+  /** Cache versioning override.  Allow read of old cache files
+      without triggering a cache recomputation. */
+  void AllowOldCache(bool allow=true) { allow_old_cache = allow; }
+
 
   //@{
   //! Get potential grid interpolated entries

--- a/utils/ICs/cylcache.cc
+++ b/utils/ICs/cylcache.cc
@@ -471,13 +471,6 @@ main(int ac, char **av)
     }
   }
 
-  // Enable new YAML cache header
-  //
-  if (vm.count("newcache")) {
-    EmpCylSL::NewCache = true;
-  }
-
-
   // Convert mtype string to lower case
   //
   std::transform(mtype.begin(), mtype.end(), mtype.begin(),

--- a/utils/ICs/initial.cc
+++ b/utils/ICs/initial.cc
@@ -663,12 +663,6 @@ main(int ac, char **av)
     }
   }
 
-  // Enable new YAML cache header
-  //
-  if (vm.count("newcache")) {
-    EmpCylSL::NewCache = true;
-  }
-
   if (vm.count("spline")) {
     SphericalModelTable::linear = 0;
   } else {


### PR DESCRIPTION
This PR promotes `totPow` and `totVar` to `bool`s and sets rules for when both are set.

Bigger questions:
- Is this an issue for backward compatibility (and does it matter)?
- Is this our long-term detrending strategy?