### PR TITLE
Fix omitted norm in OrthoFunction::dumpOrtho()

### DIFF
--- a/exputil/OrthoFunction.cc
+++ b/exputil/OrthoFunction.cc
@@ -114,7 +114,7 @@ void OrthoFunction::dumpOrtho(const std::string& filename)
       //
       Eigen::VectorXd p = poly_eval(y, nmax) * W(r);
       fout << std::setw(16) << r;
-      for (int n=0; n<nmax; n++) fout << std::setw(16) << p(n);
+      for (int n=0; n<nmax; n++) fout << std::setw(16) << p(n)/sqrt(norm[n]);
       fout << std::endl;
     }
   }


### PR DESCRIPTION
This fixed the diagnostic output and fixes no production issue.