### PR TITLE
Why doesn't `FieldGenerator` have a null constructor????!

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.25) # Needed for CUDA, MPI, and CTest features
 
 project(
   EXP
-  VERSION "7.8.5"
+  VERSION "7.8.6"
   HOMEPAGE_URL https://github.com/EXP-code/EXP
   LANGUAGES C CXX Fortran)
 

--- a/expui/FieldGenerator.H
+++ b/expui/FieldGenerator.H
@@ -36,6 +36,9 @@ namespace Field
 
   public:
     
+    //! Null constructor
+    FieldGenerator() = default;
+
     //! Constructor for a rectangular grid
     FieldGenerator(const std::vector<double> &time,
 		   const std::vector<double> &pmin,

--- a/include/DiskDensityFunc.H
+++ b/include/DiskDensityFunc.H
@@ -21,11 +21,11 @@
         creation.
 
         """
-        a = 1.0                         # Scale radius
-        h = 0.2                         # Scale height
-        f = math.exp(-math.fabs(z)/h)   # Prevent overflows
-        sech = 2.0*f / (1.0 + f*f)      # 
-        return math.exp(-R/a)*sech*sech/(4*math.pi*h*a*a)
+        a = 1.0                            # Scale radius
+        h = 0.2                            # Scale height
+        f = math.exp(-0.5*math.fabs(z)/h)  # Prevent overflows
+        sech = 2.0*f / (1.0 + f*f)         # 
+        return math.exp(-R/a)*sech*sech/(8*math.pi*h*a*a)
 	
     --------------------------cut here--------------------------------
 

--- a/pyEXP/FieldWrappers.cc
+++ b/pyEXP/FieldWrappers.cc
@@ -94,6 +94,20 @@ void FieldGeneratorClasses(py::module &m) {
   py::class_<Field::FieldGenerator, std::shared_ptr<Field::FieldGenerator>>
     f(m, "FieldGenerator");
 
+  f.def(py::init<>(),
+	R"(
+        Null constructor for FieldGenerator
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        FieldGenerator
+            new object
+        )");
+
   f.def(py::init<const std::vector<double>, const std::vector<double>,
 	const std::vector<double>, const std::vector<int>>(),
 	R"(
@@ -361,10 +375,7 @@ void FieldGeneratorClasses(py::module &m) {
 
         See also
         --------
-<<<<<<< HEAD
-=======
         points : generate fields at an array of mesh points
->>>>>>> pointMesh
         slices : generate fields in a surface slice given by the
                  initializtion grid
         volumes : generate fields in volume given by the initializtion grid


### PR DESCRIPTION
# Main change

Added a null constructor to `FieldGenerator` so that one can instantiate for use with non-grid features, e.g. using the `points()` member,  without having to supply dummy grid values.

[Some comment and docstring fixes came along for the ride.]

# Details

Add the null constructor to `FieldGenerator.H` and exposed by `pybind11`  in `FieldWrappers.cc`.

Tested in an existing work flow that I can do:
```
fields = pyEXP.field.FieldGenerator()
radii, array = fields.histo1dlog(reader, rmin, rmax, nbin)
```
Should work for other cases, such as `fields.points()`.