### PR TITLE
Fix coefficient storage allocation error

### DIFF
--- a/expui/BiorthBasis.cc
+++ b/expui/BiorthBasis.cc
@@ -294,7 +294,7 @@ namespace BasisClasses
        0, 1, cachename);
     
     // Test basis for consistency
-    orthoTest(200);
+    if (myid==0) orthoTest(200);
   }
   
   void Bessel::initialize()
@@ -320,7 +320,7 @@ namespace BasisClasses
     bess = std::make_shared<BiorthBess>(rmax, lmax, nmax, rnum);
 
     // Test basis for consistency
-    orthoTest(200);
+    if (myid==0) orthoTest(200);
   }
   
   void Spherical::reset_coefs(void)
@@ -1362,7 +1362,7 @@ namespace BasisClasses
 
     // Orthogonality sanity check
     //
-    orthoTest();
+    if (myid==0) orthoTest();
 
     // Set cylindrical coordindates
     //
@@ -1549,7 +1549,6 @@ namespace BasisClasses
     "nmaxfid",
     "rcylmin",
     "rcylmax",
-    "acyltbl",
     "numx",
     "numy",
     "numr",
@@ -1667,9 +1666,7 @@ namespace BasisClasses
     
     // Set characteristic radius defaults
     //
-    if (not conf["acyltbl"]) conf["acyltbl"] = 0.6;
     if (not conf["scale"])   conf["scale"]   = 1.0;
-
 
     // Check for non-null cache file name.  This must be specified
     // to prevent recomputation and unexpected behavior.
@@ -1689,7 +1686,7 @@ namespace BasisClasses
     
     // Orthogonality sanity check
     //
-    orthoTest();
+    if (myid==0) orthoTest();
 
     // Get max threads
     //
@@ -1735,9 +1732,12 @@ namespace BasisClasses
     cf->nmax   = nmax;
     cf->time   = time;
 
-    cf->store((2*mmax+1)*nmax);
+    // Allocate the coefficient storage
+    cf->store.resize((mmax+1)*nmax);
+
+    // Make the coefficient map
     cf->coefs = std::make_shared<CoefClasses::CylStruct::coefType>
-      (cf->store.data(), 2*mmax+1, nmax);
+      (cf->store.data(), mmax+1, nmax);
 
     for (int m=0, m0=0; m<=mmax; m++) {
       for (int n=0; n<nmax; n++) {
@@ -1806,15 +1806,15 @@ namespace BasisClasses
   {
     // Normalization factors
     //
-    constexpr double norm0 = 2.0*M_PI * 0.5*M_2_SQRTPI/M_SQRT2;
-    constexpr double norm1 = 2.0*M_PI * 0.5*M_2_SQRTPI;
+    constexpr double norm0 = 1.0;
+    constexpr double norm1 = M_SQRT2;
 
     //======================
     // Compute coefficients 
     //======================
     
     double R2 = x*x + y*y;
-    double R  = sqrt(R);
+    double R  = sqrt(R2);
     
     // Get thread id
     int tid = omp_get_thread_num();
@@ -1874,8 +1874,8 @@ namespace BasisClasses
     int tid = omp_get_thread_num();
 
     // Fixed values
-    constexpr double norm0 = 0.5*M_2_SQRTPI/M_SQRT2;
-    constexpr double norm1 = 0.5*M_2_SQRTPI;
+    constexpr double norm0 = 1.0;
+    constexpr double norm1 = M_SQRT2;
 
     double den0=0, den1=0, pot0=0, pot1=0, rpot=0, zpot=0, ppot=0;
 
@@ -2139,7 +2139,7 @@ namespace BasisClasses
 
     // Orthogonality sanity check
     //
-    orthoTest();
+    if (myid==0) orthoTest();
 
     // Get max threads
     //
@@ -2438,9 +2438,12 @@ namespace BasisClasses
     cf->nmax   = nmax;
     cf->time   = time;
 
-    cf->store((2*mmax+1)*nmax);
+    // Allocate the coefficient storage
+    cf->store.resize((mmax+1)*nmax);
+
+    // Make the coefficient map
     cf->coefs = std::make_shared<CoefClasses::CylStruct::coefType>
-      (cf->store.data(), 2*mmax+1, nmax);
+      (cf->store.data(), mmax+1, nmax);
 
     for (int m=0, m0=0; m<=mmax; m++) {
       for (int n=0; n<nmax; n++) {
@@ -2517,7 +2520,7 @@ namespace BasisClasses
     //======================
     
     double R2 = x*x + y*y;
-    double R  = sqrt(R);
+    double R  = sqrt(R2);
     
     // Get thread id
     int tid = omp_get_thread_num();
@@ -2810,7 +2813,7 @@ namespace BasisClasses
 
     // Orthogonality sanity check
     //
-    if (check) orthoTest();
+    if (check and myid==0) orthoTest();
 
     // Get max threads
     //
@@ -3248,7 +3251,7 @@ namespace BasisClasses
     
     // Orthogonality sanity check
     //
-    if (check) orthoTest();
+    if (check and myid==0) orthoTest();
 
     // Get max threads
     //


### PR DESCRIPTION
## Summary

The coefficient storage was not allocated in `FlatDisk` and `CBDisk` in `pyEXP` owing to a typo: `store()` was called instead of `store.resize()`.  Since `store` is an  `Eigen::VectorXcd`, this was valid code but not intended.

## Fixes

1. Main fix: allocate rather than access storage
2. Added a restriction to prevent each process from computing orthogonality checks when used with `mpi4py`
3. Changed normalization for `FlatDisk` and `CBDisk` to be consistent with `exp`.