### PR TITLE
Broken parameter checking in `Output` base class

### DIFF
--- a/src/Output.cc
+++ b/src/Output.cc
@@ -4,6 +4,13 @@
 
 Output::Output(const YAML::Node& CONF) : conf(CONF)
 {
-  nint = 50;			// Default interval
+  // Default interval
+  nint = 50;
   nintsub = std::numeric_limits<int>::max();
+
+  // Add keys
+  for (YAML::const_iterator it=conf.begin(); it!=conf.end(); ++it) {
+    current_keys.insert(it->first.as<std::string>());
+  }
+
 }


### PR DESCRIPTION
## Summary

The `Output` base class constructor is not copying its YAML parameters to the `current_keys` list.  This disables valid key checking.   So this is a bug although it's been like for so long, I'm calling it a feature basing the commit on `devel`.

This has been checked with several output routines and this fix appears to restore (or is it add?) the expected functionality.

Ooops.