### PR TITLE
Fix bug in `expMSSA` control flags

### DIFF
--- a/expui/expMSSA.H
+++ b/expui/expMSSA.H
@@ -85,7 +85,10 @@ namespace MSSA
     int ncomp;
 
     //! Normalization options
-    bool totVar, totPow;
+    bool varFlag, powFlag;
+
+    //! Normalization values
+    double totVar, totPow;
 
     //! Toggle for detrending
     bool useMean;

--- a/expui/expMSSA.cc
+++ b/expui/expMSSA.cc
@@ -1436,6 +1436,12 @@ namespace MSSA {
       if (params["output"] ) prefix   = params["output"].as<std::string>();
       else                   prefix   = "exp_mssa";
 
+      if (params["totVar"] ) varFlag  = params["totVar"].as<bool>();
+      else                   varFlag  = false;
+
+      if (params["totPow"] ) powFlag  = params["totPow"].as<bool>();
+      else                   powFlag  = false;
+
     }
     catch (const YAML::ParserException& e) {
       std::cout << "expMSSA::assignParameters, parsing error=" << e.what()
@@ -1521,9 +1527,11 @@ namespace MSSA {
       if (reconstructed) {
 	HighFive::Group recon = file.createGroup("reconstruction");
 
-	recon.createAttribute<int>   ("ncomp",  HighFive::DataSpace::From(ncomp) ).write(ncomp);
-	recon.createAttribute<bool>("totVar", HighFive::DataSpace::From(totVar)).write(totVar);
-	recon.createAttribute<bool>("totPow", HighFive::DataSpace::From(totVar)).write(totPow);
+	recon.createAttribute<int> ("ncomp",   HighFive::DataSpace::From(ncomp) ).write(ncomp);
+	recon.createAttribute<bool>("varFlag", HighFive::DataSpace::From(varFlag)).write(varFlag);
+	recon.createAttribute<bool>("powFlag", HighFive::DataSpace::From(powFlag)).write(powFlag);
+	recon.createAttribute<bool>("totVar",  HighFive::DataSpace::From(totVar)).write(totVar);
+	recon.createAttribute<bool>("totPow",  HighFive::DataSpace::From(totPow)).write(totPow);
 
 	for (int n=0; n<keylist.size(); n++) {
 	  std::ostringstream scnt;
@@ -1669,6 +1677,14 @@ namespace MSSA {
 	auto recon = h5file.getGroup("reconstruction");
 
 	recon.getAttribute("ncomp" ).read(ncomp);
+	if (recon.hasAttribute("varFlag"))
+	  recon.getAttribute("varFlag").read(varFlag);
+	else
+	  varFlag = false;
+	if (recon.hasAttribute("powFlag"))
+	  recon.getAttribute("powFlag").read(powFlag);
+	else
+	  powFlag = false;
 	recon.getAttribute("totVar").read(totVar);
 	recon.getAttribute("totPow").read(totPow);
 
@@ -1961,17 +1977,21 @@ namespace MSSA {
     // Detrending style (totVar and totPow are only useful, so far, for
     // noise computation)
     //
-    if (params["totVar"]) totVar = params["totVar"].as<bool>();
-    if (params["totPow"]) totPow = params["totPow"].as<bool>();
+    if (params["totVar"]) varFlag = params["totVar"].as<bool>();
+    if (params["totPow"]) powFlag = params["totPow"].as<bool>();
 
-    if (totPow==true) {
-      if (totVar==true) {
-        std::cerr << "expMSSA: both totVar and totPow are set to true."
+    std::cout << "Flags: totVar=" << std::boolalpha << varFlag
+	      << " totPow=" << std::boolalpha << powFlag << std::endl;
+    std::cout << "Flag string=" << flags << std::endl;
+
+    if (powFlag==true) {
+      if (varFlag==true) {
+        std::cerr << "expMSSA: both totVar and totPow are set to true. "
                   << "Using totPow." << std::endl;
-        totVar = false;
+        varFlag = false;
       }
       type = TrendType::totPow;
-    } else if (totVar==true) {
+    } else if (varFlag==true) {
       type = TrendType::totVar;
     } else {
       // if nothing set go default

--- a/expui/expMSSA.cc
+++ b/expui/expMSSA.cc
@@ -1530,7 +1530,7 @@ namespace MSSA {
 	recon.createAttribute<int> ("ncomp",   HighFive::DataSpace::From(ncomp) ).write(ncomp);
 	recon.createAttribute<bool>("varFlag", HighFive::DataSpace::From(varFlag)).write(varFlag);
 	recon.createAttribute<bool>("powFlag", HighFive::DataSpace::From(powFlag)).write(powFlag);
-	recon.createAttribute<bool>("totVar",  HighFive::DataSpace::From(totVar)).write(totVar);
+	recon.createAttribute<double>("totVar",  HighFive::DataSpace::From(totVar)).write(totVar);
 	recon.createAttribute<double>("totPow",  HighFive::DataSpace::From(totPow)).write(totPow);
 
 	for (int n=0; n<keylist.size(); n++) {

--- a/expui/expMSSA.cc
+++ b/expui/expMSSA.cc
@@ -1531,7 +1531,7 @@ namespace MSSA {
 	recon.createAttribute<bool>("varFlag", HighFive::DataSpace::From(varFlag)).write(varFlag);
 	recon.createAttribute<bool>("powFlag", HighFive::DataSpace::From(powFlag)).write(powFlag);
 	recon.createAttribute<bool>("totVar",  HighFive::DataSpace::From(totVar)).write(totVar);
-	recon.createAttribute<bool>("totPow",  HighFive::DataSpace::From(totPow)).write(totPow);
+	recon.createAttribute<double>("totPow",  HighFive::DataSpace::From(totPow)).write(totPow);
 
 	for (int n=0; n<keylist.size(); n++) {
 	  std::ostringstream scnt;

--- a/expui/expMSSA.cc
+++ b/expui/expMSSA.cc
@@ -1980,10 +1980,6 @@ namespace MSSA {
     if (params["totVar"]) varFlag = params["totVar"].as<bool>();
     if (params["totPow"]) powFlag = params["totPow"].as<bool>();
 
-    std::cout << "Flags: totVar=" << std::boolalpha << varFlag
-	      << " totPow=" << std::boolalpha << powFlag << std::endl;
-    std::cout << "Flag string=" << flags << std::endl;
-
     if (powFlag==true) {
       if (varFlag==true) {
         std::cerr << "expMSSA: both totVar and totPow are set to true. "

--- a/exputil/SLGridMP2.cc
+++ b/exputil/SLGridMP2.cc
@@ -120,7 +120,7 @@ double sphdens(double r)
   return 4.0*M_PI * model->get_density(r);
 }
 
-// Use entire grid for for l<Lswitch
+// Use entire grid for l<Lswitch
 int SLGridSph::Lswitch = 32;
   
 // For l>=Lswitch: rmin=rmap/rfac, rmax=rmap*rfac with rfac=pow(10,

--- a/exputil/SLGridMP2.cc
+++ b/exputil/SLGridMP2.cc
@@ -120,6 +120,13 @@ double sphdens(double r)
   return 4.0*M_PI * model->get_density(r);
 }
 
+// Use entire grid for for l<Lswitch
+int SLGridSph::Lswitch = 32;
+  
+// For l>=Lswitch: rmin=rmap/rfac, rmax=rmap*rfac with rfac=pow(10,
+// Lalpha/l)
+double SLGridSph::Lalpha = 100.0;
+
 
 void SLGridSph::bomb(string oops)
 {
@@ -1109,10 +1116,25 @@ void SLGridSph::compute_table(struct TableSph* table, int l)
   if (myid==0) VERBOSE = SLEDGE_VERBOSE;
 #endif
 
-  cons[6] = rmin;
-  cons[7] = rmax;
+  // Inner radial boundary heuristic
+  //
+  int Nlo = 0, Nhi = numr;
+  if (l>Lswitch) {
+    double Rfac = std::pow(10.0, Lalpha/l);
+    double Rmin = std::max(rmin, rmap/Rfac);
+    double Rmax = std::min(rmax, rmap*Rfac);
+
+    // Find index boundaries in r grid
+    auto lower = std::lower_bound(r.data(), r.data() + r.size(), Rmin);
+    Nlo = std::distance(r.data(), lower);
+    auto upper = std::upper_bound(r.data(), r.data() + r.size(), Rmax);
+    Nhi = std::distance(r.data(), upper);
+  }
+
+  cons[6] = r[Nlo];
+  cons[7] = r[Nhi-1];
   L2 = l*(l+1);
-  NUM = numr;
+  NUM = Nhi - Nlo;
   N = nmax;
   
   // integer iflag[nmax], invec[nmax+3];
@@ -1164,7 +1186,7 @@ void SLGridSph::compute_table(struct TableSph* table, int l)
   //
   //     Output mesh
   //
-  for (int i=0; i<NUM; i++) xef[i] = r[i];
+  for (int i=0; i<NUM; i++) xef[i] = r[i+Nlo];
 
   //     
   //     Open file for output.
@@ -1197,6 +1219,7 @@ void SLGridSph::compute_table(struct TableSph* table, int l)
     
       std::cout << std::endl
 		<< "Tolerance errors in Sturm-Liouville solver for l=" << l
+		<< ", rmin=" << cons[6] << ", rmax=" << cons[7]
 		<<  std::endl << std::endl;
 
       std::cout << std::setw(15) << "order"
@@ -1216,6 +1239,32 @@ void SLGridSph::compute_table(struct TableSph* table, int l)
       }
       std::cout << std::endl;
       
+      // Additional diagnostic output for a failed l-value computation
+      //
+      if (VERBOSE) {
+	
+	for (int i=0; i<N; i++) {
+
+	  if (iflag[i] > -10) {
+	    std::cout << "# order=" << i
+		      << " error: " << sledge_error(iflag[i])
+		      << std::endl << "#" << std::endl;
+
+	    std::cout << std::setw(14) << "x"
+		      << std::setw(25) << "u(x)"
+		      << std::setw(25) << "(pu`)(x)"
+		      << std::endl;
+	    int k = NUM*i;
+	    for (int j=0; j<NUM; j++) {
+	      std::cout << std::setw(25) << xef[j]
+			<< std::setw(25) << ef[j+k]
+			<< std::setw(25) << pdef[j+k]
+			<< std::endl;
+	    }
+	  }
+	}
+      }
+
       sout << std::endl
 	   << "SLGridSph found " << bad
 	   << " tolerance errors in computing SL solutions." << std::endl
@@ -1273,6 +1322,7 @@ void SLGridSph::compute_table(struct TableSph* table, int l)
   for (int i=0; i<N; i++) table->ev[i] = ev[i];
 
   table->ef.resize(N, numr);
+  table->ef.setZero();
 
   // Choose sign conventions for the ef table
   //
@@ -1282,9 +1332,11 @@ void SLGridSph::compute_table(struct TableSph* table, int l)
     if (ef[j*NUM+nfid]<0.0) sgn(j) = -1;
   }
   
-  for (int i=0; i<numr; i++) {
+  // Pack offset eigen function values
+  //
+  for (int i=0; i<NUM; i++) {
     for(int j=0; j<N; j++) 
-      table->ef(j, i) = ef[j*NUM+i] * sgn(j);
+      table->ef(j, i+Nlo) = ef[j*NUM+i] * sgn(j);
   }
 
   table->l = l;
@@ -1374,11 +1426,26 @@ void SLGridSph::compute_table_worker(void)
     if (tbdbg)
       std::cout << "Worker " <<  mpi_myid << ": ordered to compute l = " << L << "" << std::endl;
 
+    // Inner radial boundary heuristic
+    //
+    int Nlo = 0, Nhi = numr;
+    if (L>Lswitch) {
+      double Rfac = std::pow(10.0, Lalpha/L);
+      double Rmin = std::max(rmin, rmap/Rfac);
+      double Rmax = std::min(rmax, rmap*Rfac);
+
+      // Find index boundaries in r grid
+      auto lower = std::lower_bound(r.data(), r.data() + r.size(), Rmin);
+      Nlo = std::distance(r.data(), lower);
+      auto upper = std::upper_bound(r.data(), r.data() + r.size(), Rmax);
+      Nhi = std::distance(r.data(), upper);
+    }
+
     cons[0] = cons[1] = cons[2] = cons[3] = cons[4] = cons[5] = 0.0;
-    cons[6] = rmin;
-    cons[7] = rmax;
+    cons[6] = r[Nlo];
+    cons[7] = r[Nhi-1];
     L2 = L*(L+1);
-    NUM = numr;
+    NUM = Nhi - Nlo;
     N = nmax;
 
     // integer iflag[nmax], invec[nmax+3];
@@ -1422,7 +1489,7 @@ void SLGridSph::compute_table_worker(void)
     //
     //     Output mesh
     //
-    for (int i=0; i<NUM; i++) xef[i] = r[i];
+    for (int i=0; i<NUM; i++) xef[i] = r[i+Nlo];
 
     //     
     //     Open file for output.
@@ -1454,6 +1521,7 @@ void SLGridSph::compute_table_worker(void)
     
       std::cout << std::endl
 		<< "Tolerance errors in Sturm-Liouville solver for l=" << L
+		<< ", rmin=" << cons[6] << ", rmax=" << cons[7]
 		<<  std::endl << std::endl;
 
       std::cout << std::setw(15) << "order"
@@ -1523,10 +1591,16 @@ void SLGridSph::compute_table_worker(void)
       if (ef[j*NUM+nfid]<0.0) sgn(j) = -1;
     }
 
+    // Allocate table
+    //
     table.ef.resize(N, numr);
-    for (int i=0; i<numr; i++) {
-      for (int j=0; j<N; j++) 
-	table.ef(j, i) = ef[j*NUM+i] * sgn(j);
+    table.ef.setZero();
+
+    // Pack offset eigen function values
+    //
+    for (int i=0; i<NUM; i++) {
+      for(int j=0; j<N; j++) 
+	table.ef(j, i+Nlo) = ef[j*NUM+i] * sgn(j);
     }
 
     table.l = L;
@@ -2833,7 +2907,7 @@ void SLGridSlab::compute_table(struct TableSlab* table, int KX, int KY)
 		<< std::setw( 5) << iflag[i]
 		<< std::endl;
   
-      if (VERBOSE) {
+      if (VERBOSE and iflag[i] != 0) {
 
 	if (iflag[i] > -10) {
 	  cout << std::setw(14) << "x"

--- a/include/SLGridMP2.H
+++ b/include/SLGridMP2.H
@@ -94,6 +94,18 @@ private:
   //! Cache versioning
   inline static const std::string Version = "1.0";
 
+  //@{
+  /** Rmin heuristic for grid construction to prevent underflow issues
+      in Sturm-Liouville solver: sledge */
+
+  //! Use entire grid for l<Lswitch
+  static int Lswitch;
+  
+  //! For l>=Lswitch:
+  //! rmin=rmap/rfac, rmax=rmap*rfac with rfac=pow(10, Lalpha/l)
+  static double Lalpha;
+  //@}
+
 public:
 
   //! Flag for MPI enabled (default: 0=off)


### PR DESCRIPTION
## The issue
The `expMSSA` header defines `totVar` and `totPow` as boolean but uses them as doubles to compute the norm.  Not sure how this is legal code?  But that's how it appears.

## The fix
1. Make `totVar` and `totPow` doubles. 
2. Add `varFlag` and `powFlag` as boolean class data set by the `totVar` and `totPow` YAM configuration flag
3. Added both flags and values to the HDF5 cache files
4. Added some verbose log output for testing to verify that the logic is working as expected.

## Notes
While this is formally a big, I think, I'm basing the PR on `devel`, anticipating an upcoming merge to `main`