### PR TITLE
Add a Unit class to EXP coefficients [WIP]

### DIFF
--- a/expui/BasisFactory.H
+++ b/expui/BasisFactory.H
@@ -136,6 +136,9 @@ namespace BasisClasses
     //! Get the current pseudo acceleration value
     Eigen::Vector3d currentAccel(double time);
 
+    //! Gravitational constant
+    double G = 1.0;
+
   public:
 
     //! The current pseudo acceleration

--- a/expui/BiorthBasis.cc
+++ b/expui/BiorthBasis.cc
@@ -328,6 +328,7 @@ namespace BasisClasses
     if (expcoef.rows()>0 && expcoef.cols()>0) expcoef.setZero();
     totalMass = 0.0;
     used = 0;
+    G = 1.0;
   }
   
   
@@ -340,6 +341,8 @@ namespace BasisClasses
     cf->scale  = scale;
     cf->time   = time;
     cf->normed = true;
+
+    G = cf->G;
 
     // Angular storage dimension
     int ldim = (lmax+1)*(lmax+2)/2;
@@ -395,6 +398,10 @@ namespace BasisClasses
     }
     
     CoefClasses::SphStruct* cf = dynamic_cast<CoefClasses::SphStruct*>(coef.get());
+
+    // Set gravitational constant
+    //
+    G = cf->G;
 
     // Cache the current coefficient structure
     //
@@ -594,7 +601,7 @@ namespace BasisClasses
     }
     
     double densfac = 1.0/(scale*scale*scale) * 0.25/M_PI;
-    double potlfac = 1.0/scale;
+    double potlfac = G/scale;
 
     return
       {den0 * densfac,		// 0
@@ -700,7 +707,7 @@ namespace BasisClasses
       }
     }
     
-    double potlfac = 1.0/scale;
+    double potlfac = G/scale;
 
     potr *= (-potlfac)/scale;
     pott *= (-potlfac);
@@ -746,7 +753,7 @@ namespace BasisClasses
     double tpotx = v[6]*x/R - v[8]*y/R ;
     double tpoty = v[6]*y/R + v[8]*x/R ;
     
-    return {v[0], v[1], v[2], v[3], v[4], v[5], tpotx, tpoty, v[7]};
+    return {v[0], v[1], v[2], v[3]*G, v[4]*G, v[5]*G, tpotx*G, tpoty*G, v[7]*G};
   }
   
   Spherical::BasisArray SphericalSL::getBasis
@@ -1486,6 +1493,12 @@ namespace BasisClasses
     double tdens0, tdens, tpotl0, tpotl, tpotR, tpotz, tpotp;
     
     sl->accumulated_eval(R, z, phi, tpotl0, tpotl, tpotR, tpotz, tpotp);
+
+    tpotl0 *= G;
+    tpotl  *= G;
+    tpotR  *= G;
+    tpotz  *= G;
+    tpotp  *= G;
     
     tdens = sl->accumulated_dens_eval(R, z, phi, tdens0);
 
@@ -1506,6 +1519,12 @@ namespace BasisClasses
     double tdens0, tdens, tpotl0, tpotl, tpotR, tpotz, tpotp;
 
     sl->accumulated_eval(R, z, phi, tpotl0, tpotl, tpotR, tpotz, tpotp);
+
+    tpotl0 *= G;
+    tpotl  *= G;
+    tpotR  *= G;
+    tpotz  *= G;
+    tpotp  *= G;
     
     tdens = sl->accumulated_dens_eval(R, z, phi, tdens0);
 
@@ -1532,7 +1551,7 @@ namespace BasisClasses
     double tpotx = tpotR*x/R - tpotp*y/R ;
     double tpoty = tpotR*y/R + tpotp*x/R ;
 
-    return {tpotx, tpoty, tpotz};
+    return {tpotx*G, tpoty*G, tpotz*G};
   }
 
   // Evaluate in cylindrical coordinates
@@ -1542,6 +1561,12 @@ namespace BasisClasses
 
     sl->accumulated_eval(R, z, phi, tpotl0, tpotl, tpotR, tpotz, tpotp);
     tdens = sl->accumulated_dens_eval(R, z, phi, tdens0);
+
+    tpotl0 *= G;
+    tpotl  *= G;
+    tpotR  *= G;
+    tpotz  *= G;
+    tpotp  *= G;
 
     if (midplane) {
       height = sl->accumulated_midplane_eval(R, -colh*hcyl, colh*hcyl, phi);
@@ -1577,6 +1602,8 @@ namespace BasisClasses
     cf->nmax   = nmax;
     cf->time   = time;
 
+    G = cf->G;
+
     Eigen::VectorXd cos1(nmax), sin1(nmax);
 
     // Initialize the values
@@ -1605,6 +1632,10 @@ namespace BasisClasses
       throw std::runtime_error("Cylindrical::set_coefs: you must pass a CoefClasses::CylStruct");
 
     CoefClasses::CylStruct* cf = dynamic_cast<CoefClasses::CylStruct*>(coef.get());
+
+    // Set gravitational constant
+    //
+    G = cf->G;
 
     // Cache the current coefficient structure
     //
@@ -1849,6 +1880,7 @@ namespace BasisClasses
     if (expcoef.rows()>0 && expcoef.cols()>0) expcoef.setZero();
     totalMass = 0.0;
     used = 0;
+    G = 1.0;
   }
   
   
@@ -1859,6 +1891,8 @@ namespace BasisClasses
     cf->mmax   = mmax;
     cf->nmax   = nmax;
     cf->time   = time;
+
+    G = cf->G;
 
     // Allocate the coefficient storage
     cf->store.resize((mmax+1)*nmax);
@@ -1906,6 +1940,10 @@ namespace BasisClasses
     
     CoefClasses::CylStruct* cf = dynamic_cast<CoefClasses::CylStruct*>(coef.get());
     auto & cc = *cf->coefs;
+
+    // Set gravitational constant
+    //
+    G = cf->G;
 
     // Cache the current coefficient structure
     //
@@ -2090,11 +2128,11 @@ namespace BasisClasses
 
     den0 *= -1.0;
     den1 *= -1.0;
-    pot0 *= -1.0;
-    pot1 *= -1.0;
-    rpot *= -1.0;
-    zpot *= -1.0;
-    ppot *= -1.0;
+    pot0 *= -G;
+    pot1 *= -G;
+    rpot *= -G;
+    zpot *= -G;
+    ppot *= -G;
 
     return {den0, den1, den0+den1, pot0, pot1, pot0+pot1, rpot, zpot, ppot};
   }
@@ -2650,6 +2688,7 @@ namespace BasisClasses
     if (expcoef.rows()>0 && expcoef.cols()>0) expcoef.setZero();
     totalMass = 0.0;
     used = 0;
+    G = 1.0;
   }
   
   
@@ -2660,6 +2699,8 @@ namespace BasisClasses
     cf->mmax   = mmax;
     cf->nmax   = nmax;
     cf->time   = time;
+
+    G = cf->G;
 
     // Allocate the coefficient storage
     cf->store.resize((mmax+1)*nmax);
@@ -2707,6 +2748,10 @@ namespace BasisClasses
     
     CoefClasses::CylStruct* cf = dynamic_cast<CoefClasses::CylStruct*>(coef.get());
     auto & cc = *cf->coefs;
+
+    // Set gravitational constant
+    //
+    G = cf->G;
 
     // Cache the current coefficient structure
     coefret = coef;
@@ -3135,6 +3180,7 @@ namespace BasisClasses
     expcoef.setZero();
     totalMass = 0.0;
     used = 0;
+    G = 1.0;
   }
   
   
@@ -3146,6 +3192,8 @@ namespace BasisClasses
     cf->nmaxy   = nmaxy;
     cf->nmaxz   = nmaxz;
     cf->time    = time;
+
+    G = cf->G;
 
     cf->allocate();
 
@@ -3179,6 +3227,10 @@ namespace BasisClasses
     
     auto cf = dynamic_cast<CoefClasses::SlabStruct*>(coef.get());
     expcoef = *cf->coefs;
+
+    // Set gravitational constant
+    //
+    G = cf->G;
 
     // Cache the current coefficient structure
     //
@@ -3648,6 +3700,7 @@ namespace BasisClasses
     expcoef.setZero();
     totalMass = 0.0;
     used = 0;
+    G = 1.0;
   }
   
   
@@ -3659,6 +3712,8 @@ namespace BasisClasses
     cf->nmaxy   = nmaxy;
     cf->nmaxz   = nmaxz;
     cf->time    = time;
+
+    G = cf->G;
 
     cf->allocate();
 
@@ -3692,6 +3747,10 @@ namespace BasisClasses
     
     auto cf = dynamic_cast<CoefClasses::CubeStruct*>(coef.get());
     expcoef = *cf->coefs;
+
+    // Set gravitational constant
+    //
+    G = cf->G;
 
     // Cache the cuurent coefficient structure
     //

--- a/expui/BiorthBasis.cc
+++ b/expui/BiorthBasis.cc
@@ -753,7 +753,7 @@ namespace BasisClasses
     double tpotx = v[6]*x/R - v[8]*y/R ;
     double tpoty = v[6]*y/R + v[8]*x/R ;
     
-    return {v[0], v[1], v[2], v[3]*G, v[4]*G, v[5]*G, tpotx*G, tpoty*G, v[7]*G};
+    return {v[0], v[1], v[2], v[3], v[4], v[5], tpotx, tpoty, v[7]};
   }
   
   Spherical::BasisArray SphericalSL::getBasis
@@ -2053,9 +2053,9 @@ namespace BasisClasses
     if (R>ortho->getRtable() or fabs(z)>ortho->getRtable()) {
       double r2 = R*R + z*z;
       double r  = sqrt(r2);
-      pot0 = -totalMass/r;
-      rpot = -totalMass*R/(r*r2 + 10.0*std::numeric_limits<double>::min());
-      zpot = -totalMass*z/(r*r2 + 10.0*std::numeric_limits<double>::min());
+      pot0 = -G*totalMass/r;
+      rpot = -G*totalMass*R/(r*r2 + 10.0*std::numeric_limits<double>::min());
+      zpot = -G*totalMass*z/(r*r2 + 10.0*std::numeric_limits<double>::min());
       
       return {den0, den1, den0+den1, pot0, pot1, pot0+pot1, rpot, zpot, ppot};
     }
@@ -2158,8 +2158,8 @@ namespace BasisClasses
       double r2 = R*R + z*z;
       double r  = sqrt(r2);
 
-      rpot = -totalMass*R/(r*r2 + 10.0*std::numeric_limits<double>::min());
-      zpot = -totalMass*z/(r*r2 + 10.0*std::numeric_limits<double>::min());
+      rpot = -G*totalMass*R/(r*r2 + 10.0*std::numeric_limits<double>::min());
+      zpot = -G*totalMass*z/(r*r2 + 10.0*std::numeric_limits<double>::min());
       
       return {rpot, zpot, ppot};
     }
@@ -2218,9 +2218,9 @@ namespace BasisClasses
       }
     }
 
-    rpot *= -1.0;
-    zpot *= -1.0;
-    ppot *= -1.0;
+    rpot *= -G;
+    zpot *= -G;
+    ppot *= -G;
 
     double potx = rpot*x/R - ppot*y/R;
     double poty = rpot*y/R + ppot*x/R;
@@ -2910,10 +2910,10 @@ namespace BasisClasses
 
     den0 *= -1.0;
     den1 *= -1.0;
-    pot0 *= -1.0;
-    pot1 *= -1.0;
-    rpot *= -1.0;
-    ppot *= -1.0;
+    pot0 *= -G;
+    pot1 *= -G;
+    rpot *= -G;
+    ppot *= -G;
 
     return {den0, den1, den0+den1, pot0, pot1, pot0+pot1, rpot, zpot, ppot};
   }
@@ -2977,8 +2977,8 @@ namespace BasisClasses
       }
     }
 
-    rpot *= -1.0;
-    ppot *= -1.0;
+    rpot *= -G;
+    ppot *= -G;
 
 
     double potx = rpot*x/R - ppot*y/R;
@@ -3472,7 +3472,7 @@ namespace BasisClasses
       }
     }
 
-    return {accx.real(), accy.real(), accz.real()};
+    return {G*accx.real(), G*accy.real(), G*accz.real()};
   }
 
 
@@ -3483,7 +3483,7 @@ namespace BasisClasses
 
     auto [pot, den, frcx, frcy, frcz] = eval(x, y, z);
 
-    return {0, den, den, 0, pot, pot, frcx, frcy, frcz};
+    return {0, den, den, 0, pot*G, pot*G, frcx*G, frcy*G, frcz*G};
   }
 
   std::vector<double> Slab::cyl_eval(double R, double z, double phi)
@@ -3500,11 +3500,11 @@ namespace BasisClasses
     double potp = -frcx*sin(phi) + frcy*cos(phi);
     double potz =  frcz;
 
-    potR *= -1;
-    potp *= -1;
-    potz *= -1;
+    potR *= -G;
+    potp *= -G;
+    potz *= -G;
 
-    return {0, den, den, 0, pot, pot, potR, potz, potp};
+    return {0, den, den, 0, pot*G, pot*G, potR, potz, potp};
   }
 
   std::vector<double> Slab::sph_eval(double r, double costh, double phi)
@@ -3522,11 +3522,11 @@ namespace BasisClasses
     double pott =  frcx*cos(phi)*costh + frcy*sin(phi)*costh - frcz*sinth;
     double potp = -frcx*sin(phi)       + frcy*cos(phi);
 
-    potr *= -1;
-    pott *= -1;
-    potp *= -1;
+    potr *= -G;
+    pott *= -G;
+    potp *= -G;
     
-    return {0, den, den, 0, pot, pot, potr, pott, potp};
+    return {0, den, den, 0, pot*G, pot*G, potr, pott, potp};
   }
 
 
@@ -3841,7 +3841,7 @@ namespace BasisClasses
     double frcy = -frc(1).real();
     double frcz = -frc(2).real();
 
-    return {0, den1, den1, 0, pot1, pot1, frcx, frcy, frcz};
+    return {0, den1, den1, 0, pot1*G, pot1*G, frcx*G, frcy*G, frcz*G};
   }
 
   std::vector<double> Cube::getAccel(double x, double y, double z)
@@ -3855,7 +3855,7 @@ namespace BasisClasses
     // Get the basis fields
     auto frc = ortho->get_force(expcoef, pos);
     
-    return {-frc(0).real(), -frc(1).real(), -frc(2).real()};
+    return {-G*frc(0).real(), -G*frc(1).real(), -G*frc(2).real()};
   }
 
   std::vector<double> Cube::cyl_eval(double R, double z, double phi)
@@ -3873,7 +3873,7 @@ namespace BasisClasses
     double den1 = ortho->get_dens(expcoef, pos).real();
     double pot1 = ortho->get_pot (expcoef, pos).real();
 
-    auto frc = ortho->get_force(expcoef, pos);
+    auto frc = ortho->get_force(expcoef, pos)*G;
     
     double frcx = frc(0).real(), frcy = frc(1).real(), frcz = frc(2).real();
 
@@ -3902,7 +3902,7 @@ namespace BasisClasses
 
     // Get the basis fields
     double den1 = ortho->get_dens(expcoef, pos).real();
-    double pot1 = ortho->get_pot (expcoef, pos).real();
+    double pot1 = ortho->get_pot (expcoef, pos).real() * G;
 
     auto frc = ortho->get_force(expcoef, pos);
     
@@ -3914,9 +3914,9 @@ namespace BasisClasses
     double pott =  frcx*cos(phi)*costh + frcy*sin(phi)*costh - frcz*sinth;
     double potp = -frcx*sin(phi)       + frcy*cos(phi);
 
-    potr *= -1;
-    pott *= -1;
-    potp *= -1;
+    potr *= -G;
+    pott *= -G;
+    potp *= -G;
     
     return {0, den1, den1, 0, pot1, pot1, potr, pott, potp};
   }

--- a/expui/CoefStruct.H
+++ b/expui/CoefStruct.H
@@ -23,6 +23,9 @@ namespace CoefClasses
     //! Time stamp
     double time;
     
+    //! Gravitational constant
+    double G = 1.0;
+
     //! Coefficient data
     Eigen::VectorXcd store;
     
@@ -81,6 +84,9 @@ namespace CoefClasses
 
     //! Read-only access to center (no copy)
     double getTime() { return time; }
+
+    //! Set gravitational constant
+    void setGravConstant(double val) { G = val; }
 
   };
   

--- a/expui/Coefficients.H
+++ b/expui/Coefficients.H
@@ -37,11 +37,13 @@ namespace CoefClasses
 
     Unit(std::string n, std::string u, float v) : value(v)
     {
-      std::memset(name, 0, 16); std::memset(unit, 0, 16);
-      size_t arraySize = n.length() + 1, sz = strlen(name);
-      strncpy(name, n.c_str(), std::min(arraySize, sz));
-      arraySize = u.length() + 1; sz = strlen(unit);
-      strncpy(unit, u.c_str(), std::min(arraySize, sz));
+      // Constant string size
+      const size_t sz=16;
+      // Zero fill
+      std::memset(name, 0, sz); std::memset(unit, 0, sz);
+      // Copy strings to char arrays
+      strncpy(name, n.c_str(), std::min(n.length()+1, sz));
+      strncpy(unit, u.c_str(), std::min(u.length()+1, sz));
     }
 
   };
@@ -106,8 +108,8 @@ namespace CoefClasses
     //! Time offset for interpolation
     double deltaT;
 
-    //! Default units
-    std::vector<Unit> units {{"G", "", 1.0f}};
+    //! Default units (EXP native)
+    std::vector<Unit> units {{"G", "none", 1.0f}};
 
   public:
     

--- a/expui/Coefficients.H
+++ b/expui/Coefficients.H
@@ -5,7 +5,7 @@
 #include <stdexcept> 
 
 // Needed by member functions for writing parameters and stanzas
-#include <highfive/H5File.hpp>
+#include <highfive/highfive.hpp>
 
 #include <Eigen/Eigen>	      // Store coefficient matrices and 2d grids
 #include <unsupported/Eigen/CXX11/Tensor> // For 3d rectangular grids?
@@ -24,8 +24,27 @@ namespace CoefClasses
   using E2d = 
   Eigen::Matrix<std::complex<double>,
 		Eigen::Dynamic,	Eigen::Dynamic,	Eigen::ColMajor>;
-    
+  
   using E3d = Eigen::Tensor<std::complex<double>, 3>;
+
+  // A struct for a single unit metadatum
+  struct Unit {
+    char name[16];		//! The name of the physical value in ascii
+    char unit[16];		//! The unit type in ascii
+    float value;			//! The value as a float
+
+    Unit() { std::memset(name, 0, 16); std::memset(unit, 0, 16); value=0.0f; }
+
+    Unit(std::string n, std::string u, float v) : value(v)
+    {
+      std::memset(name, 0, 16); std::memset(unit, 0, 16);
+      size_t arraySize = n.length() + 1, sz = strlen(name);
+      strncpy(name, n.c_str(), std::min(arraySize, sz));
+      arraySize = u.length() + 1; sz = strlen(unit);
+      strncpy(unit, u.c_str(), std::min(arraySize, sz));
+    }
+
+  };
 
   /** 
       Abstract class for any type of coefficient database
@@ -86,6 +105,9 @@ namespace CoefClasses
 
     //! Time offset for interpolation
     double deltaT;
+
+    //! Default units
+    std::vector<Unit> units {{"G", "", 1.0f}};
 
   public:
     
@@ -197,6 +219,21 @@ namespace CoefClasses
 
     //! Set maximum grid interpolation offset
     void setDeltaT(double dT) { deltaT = dT; }
+
+    //! Set units
+    void setUnit(std::string name, std::string unit, float value);
+
+    //! Write units to H5
+    void WriteH5Units(HighFive::File& file);
+
+    //! Read units from H5
+    void ReadH5Units(HighFive::File& file);
+
+    //! Get units
+    std::vector<std::tuple<std::string, std::string, float>> getUnits();
+
+    //! Get gravitational constant
+    double getGravConstant();
 
     class CoefsError : public std::runtime_error
     {

--- a/expui/Coefficients.H
+++ b/expui/Coefficients.H
@@ -28,7 +28,8 @@ namespace CoefClasses
   using E3d = Eigen::Tensor<std::complex<double>, 3>;
 
   // A struct for a single unit metadatum
-  struct Unit {
+  struct Unit
+  {
     char name[16];		//! The name of the physical value in ascii
     char unit[16];		//! The unit type in ascii
     float value;			//! The value as a float

--- a/expui/Coefficients.cc
+++ b/expui/Coefficients.cc
@@ -1,3 +1,6 @@
+
+
+
 #include <filesystem>
 #include <iterator>
 #include <iostream>
@@ -128,8 +131,10 @@ namespace CoefClasses
   void Coefs::ReadH5Units(HighFive::File& file)
   {
     if (file.exist("Units")) {
-    HighFive::DataSet dataset = file.getDataSet("Units");
-    units = dataset.read<std::vector<Unit>>();
+      HighFive::DataSet dataset = file.getDataSet("Units");
+      units = dataset.read<std::vector<Unit>>();
+      std::cout << "Coefs::ReadH5Units: read units from HDF5 file:" << std::endl;
+      std::cout << units;
     }
   }
 
@@ -2560,6 +2565,8 @@ namespace CoefClasses
       HighFive::Attribute geom = h5file.getAttribute("geometry");
       geom.read(geometry);
       
+      // Now try to deduce the coefficient type
+      //
       try {
 	// Is the set a biorthogonal basis (has the forceID attribute)
 	// or general basis (fieldID attribute)?
@@ -2597,6 +2604,10 @@ namespace CoefClasses
 	throw std::runtime_error(msg + err.what());
       }
 	
+      // Attempt to red units
+      //
+      coefs->ReadH5Units(h5file);
+
       return coefs;
       
     } catch (HighFive::Exception& err) {
@@ -2791,6 +2802,10 @@ namespace CoefClasses
       //
       HighFive::File file(prefix, HighFive::File::ReadWrite);
       
+      // Attempt to read units
+      //
+      ReadH5Units(file);
+
       // Get the dataset
       HighFive::DataSet dataset = file.getDataSet("count");
       

--- a/expui/Coefficients.cc
+++ b/expui/Coefficients.cc
@@ -31,8 +31,32 @@ HighFive::CompoundType create_compound_Unit() {
 HIGHFIVE_REGISTER_TYPE(CoefClasses::Unit, create_compound_Unit)
 
 
+// Helper ostream manipulator for debugging Unit info
+std::ostream& operator<< (std::ostream& out,
+			  const std::vector<CoefClasses::Unit>& t)
+{
+  out << std::string(48, '-') << std::endl
+      << std::setw(16) << "Name"
+      << std::setw(16) << "Unit"
+      << std::setw(16) << "Value"
+      << std::endl
+      << std::setw(16) << std::string(10, '-')
+      << std::setw(16) << std::string(10, '-')
+      << std::setw(16) << std::string(10, '-')
+      << std::endl;
+  for (auto p : t)
+    out << std::setw(16) << p.name
+	<< std::setw(16) << p.unit
+	<< std::setw(16) << p.value
+	<< std::endl;
+  out << std::string(48, '-') << std::endl;
+  
+  return out;
+}
+
 namespace CoefClasses
 {
+
   void Coefs::copyfields(std::shared_ptr<Coefs> p)
   {
     // These variables will copy data, not pointers
@@ -44,13 +68,17 @@ namespace CoefClasses
     p->times    = times;
   }
 
-  void Coefs::setUnit(std::string name, std::string unit, float value)
+  void Coefs::setUnit(std::string Name, std::string Unit, float Value)
   {
     auto copy_s = [](std::string& s, char* c) -> void {
-      size_t arraySize = s.length() + 1, sz = strlen(c);
-      strncpy(c, s.c_str(), std::min(arraySize, sz));
+      const size_t sz = 16;
+      strncpy(c, s.c_str(), std::min(s.length()+1, sz));
     };
       
+    // Keep copy with original case
+    std::string name(Name);
+
+    // Convert to lower case for matching
     std::transform(name.begin(), name.end(), name.begin(),
 		   [](unsigned char c){ return std::tolower(c); });
 
@@ -61,14 +89,14 @@ namespace CoefClasses
 		     [](unsigned char c){ return std::tolower(c); });
 
       if (name.find(p_name) == 0) {
-	copy_s(unit, &p.unit[0]);
-	p.value = value;
+	copy_s(Unit, &p.unit[0]);
+	p.value = Value;
 	return;
       }
     }
 
     // No matches
-    units.push_back({name, unit, value});
+    units.push_back({Name, Unit, Value});
   }
 
   //! Get units
@@ -94,6 +122,7 @@ namespace CoefClasses
   void Coefs::WriteH5Units(HighFive::File& file)
   {
     HighFive::DataSet dataset = file.createDataSet("Units", units);
+    std::cout << units;
   }
 
   void Coefs::ReadH5Units(HighFive::File& file)

--- a/pyEXP/CoefWrappers.cc
+++ b/pyEXP/CoefWrappers.cc
@@ -1134,6 +1134,25 @@ void CoefficientClasses(py::module &m) {
             list(float,...)
                 list of times
             )")
+    .def("setUnit",
+            &CoefClasses::Coefs::setUnit,
+            R"(
+            Set the units for the coefficient struction.
+
+            Parameters
+            ----------
+	    name : str
+               the name of physical quantity (G, Length, Mass, Time, etc)
+            unit : str
+               the unit string (scalar, mixed, kpc, Msun, Myr, km/s etc.).
+               This field is optional and can be empty.
+            value : float
+	       the default value of the multiples of the unit
+
+            Returns
+            -------
+            None
+            )", py::arg("name"), py::arg("unit")="", py::arg("value")=1.0)
     .def("WriteH5Coefs",
             &CoefClasses::Coefs::WriteH5Coefs,
             R"(

--- a/pyEXP/CoefWrappers.cc
+++ b/pyEXP/CoefWrappers.cc
@@ -1154,8 +1154,15 @@ void CoefficientClasses(py::module &m) {
             None
             )", py::arg("name"), py::arg("unit")="", py::arg("value")=1.0)
     .def("WriteH5Coefs",
-            &CoefClasses::Coefs::WriteH5Coefs,
-            R"(
+	 [](CoefClasses::Coefs& self, const std::string& filename) {
+	   if (self.getUnits().size()==1) {
+	     std::cout << "Coefs::WriteH5Coefs: please set units for your coefficient set using the `setUnit()` member," << std::endl
+		       << "                     one for each unit.  We suggest explicitly setting 'G', 'Length', 'Mass'," << std::endl
+		       << "                     'Time', and optionally 'Velocity' before writing HDF5 coefficients" << std::endl;
+	   }
+	   self.WriteH5Coefs(filename);
+	 },
+	 R"(
             Write the coefficients into an EXP HDF5 coefficient file with the given prefix name.
 
             Parameters
@@ -1173,7 +1180,8 @@ void CoefficientClasses(py::module &m) {
             coefficient file already exists.  This is a safety
             feature.  If you'd like a new version of this file, delete
             the old before this call.
-            )",py::arg("filename"))
+            )",
+	 py::arg("filename"))
     .def("ExtendH5Coefs",
             &CoefClasses::Coefs::ExtendH5Coefs,
             R"(

--- a/pyEXP/CoefWrappers.cc
+++ b/pyEXP/CoefWrappers.cc
@@ -770,6 +770,26 @@ void CoefficientClasses(py::module &m) {
           --------
           setCenter : read-write access to the center data
           )")
+    .def("setGravConstant", &CoefStruct::setGravConstant,
+          py::arg("G"),
+          R"(
+          Set the gravitational constant
+  
+          Parameters
+          ----------
+          G  : float
+             gravitational constant, default is 1.0
+  
+          Returns
+          -------
+          None
+  
+          Notes
+          -----
+          The gravitational constant is used for field evaluation for
+          biorthogonal basis sets.  It will be set autoomatically when
+          reading EXP coefficient files.
+          )")
     .def("setCoefCenter",
           static_cast<void (CoefStruct::*)(std::vector<double>&)>(&CoefStruct::setCenter),
           py::arg("mat"),
@@ -1258,6 +1278,15 @@ void CoefficientClasses(py::module &m) {
          bool
              True if the data is identical, False otherwise.
          )")
+    .def("getUnits", &CoefClasses::Coefs::getUnits,
+         R"(
+         Get the units of the coefficient data
+
+         Returns
+         -------
+         list((str,str,float))
+             list of
+         )")
     .def_static("factory", &CoefClasses::Coefs::factory,
               R"(
               Deduce the type and read coefficients from a native or HDF5 file
@@ -1308,6 +1337,7 @@ void CoefficientClasses(py::module &m) {
                 addcoef : add coefficient structures to an existing coefficieint container
                 )",
 		py::arg("coef"), py::arg("name")="");
+
 
   py::class_<CoefClasses::SphCoefs, std::shared_ptr<CoefClasses::SphCoefs>, PySphCoefs, CoefClasses::Coefs>
     (m, "SphCoefs", "Container for spherical coefficients")


### PR DESCRIPTION
# Summary
- `Unit` class provides the three fields `(name as char[16], unit as char[16], value as float)`.  
- We need fixed strings for HDF5 compound types.  
- The `Coefs` base class maintains a `std::vector<Unit>` container, written to coefficient files as an HDF5 `dataset`
- This can be read and written by `h5py` as an array of `dtype([('name', 'S16'), ('unit', 'S16'), ('value', '<f4')])`

# EXP integration
- The `Unit` instance `("G", "none", 1.0f)` is the default.  Applications can call the `setUnit(name, unit, value)` member function to add units.  The intent is that the `unit` field is one of the standard astronomically common units, e.g. as used by `astropy`.  However, `Unit` does no checking.  I suggest the standard name fields `Length`, `Time`, `Mass`, `Velocity` and `G` but there is no name checking.
- Calling `setUnit` will check for the `name` in the array and replace units and values.  The matching is case _insensitive_.  One call is needed for each unit.
- The `Coefs` class will populate the `Unit` array on read.
- The `Coefs` class provides a `getUnits()` member which returns a vector of tuples as `<std::string, std::string, float>` and a `getGravConstant()` member that returns the value of the gravitational constant only

# pyEXP integration
- The members `setUnit()`,  `getUnits()` and `getGravConstant()` are bound to `pyEXP.coefs.Coefs` interface
- In addition, the field quantities returned by `pyEXP::Basis` will scale potential and force quantities with the current value of the gravitational constant
- Users creating coefficient files from `pyEXP` will be warned/encouraged to provide unit data if no units have been set.

# Gala integration strategy
Now that I understand the Gala/astropy units concept, we should be able to use both `UnitSystem` and `SimulationUnitSystem` depending on the user's need.   One might be begin by using the `pyEXP.Coefs.getUnits()` to pull vector of tuples that describe the user's units.  There are two clear-cut cases:
1. The user stipulates `G=1` with a supplied `Mass` and `Length` unit.  In that case, Gala can create a `SimulationUnitSystem` object.
2. The user specifies `G!=1` with either `Mass`, `Length`, and `Velocity` or `Mass`, `Length`, and `Time`.  In that case, Gala can create a `UnitSystem` and the value of `G` will be handled correctly by `pyEXP`.  There is an obvious internal check: the implied value of `G` by the three supplied physical units should match (with some tolerance) the supplied value of `G`.  Note: `G` is a required field in `exp` in the current implementation.  So this should be unambiguous; e.g. the user can not specify `Mass`, `Length`, and `Time` and not specify `G`.  Alternatively, I could attempt to do the unit parsing on the `pyEXP` side.  But that seems like inappropriate duplication of existing code.

# Checks

- [ ] The code compiles
- [ ] The `Unit` vector is correctly created by `Coefs`
- [ ] The `Unit` vector is correctly serialized into HDF5
- [ ] The `Units` dataset is correctly read by `h5py` and `EXP`
- [ ] The `Units` are correctly reread when the coefficient dataset is extended during an `exp` simulation
- [ ] Non unit values of `G` are correctly handed by the `pyEXP.basis.Basis` classes
- [ ] Add appropriate documentation for the final version
