### PR TITLE
Updates to DEBUG diagnostic code

### DIFF
--- a/exputil/orbit_trans.cc
+++ b/exputil/orbit_trans.cc
@@ -73,7 +73,7 @@ void SphericalOrbit::compute_freq(void)
   xmin = ZFRAC*model->get_min_radius();
   xmax = model->get_max_radius();
 
-  // Functor whose zero locates radius of circular orbit with energy EE
+  // Functor whose zero locates radius of circular orbit
   //
   auto Ecirc = [&](double r)
   {
@@ -123,7 +123,7 @@ void SphericalOrbit::compute_freq(void)
   if (dudr>0.0) jmax = sqrt(r_circ*r_circ*r_circ*dudr);
   else          jmax = 0.0;
 
-  // Functor whose zero locates turning points for orbit (EE,JJ) 
+  // Functor whose zero locates turning points for orbit
   //
   auto denom = [&](double r)
   {
@@ -266,7 +266,7 @@ void SphericalOrbit::compute_freq(void)
       ostringstream msg;
 
       msg << "\t\tdenominator [1] out of bounds" << endl;
-      msg << "E=" << EE << "  K=" << KK << 
+      msg << "E=" << energy << "  K=" << kappa << 
 	" r=" << r << " i=" << i << "/" << FRECS << " val=" << tmp2 << endl;
 
       tmp2 = 2.0*(energy-model->get_pot(r_peri)) - 
@@ -299,7 +299,7 @@ void SphericalOrbit::compute_freq(void)
       ostringstream msg;
 
       msg << "\t\t denominator [2] out of bounds" << endl;
-      msg << "\t\tE=" << EE << "  K=" << KK << 
+      msg << "\t\tE=" << energy << "  K=" << kappa << 
 	" r=" << r << " i=" << i << "/" << FRECS << " val=" << tmp2 << endl;
 
       tmp2 = 2.0*(energy-model->get_pot(r_peri)) - 

--- a/exputil/realize_model.cc
+++ b/exputil/realize_model.cc
@@ -406,7 +406,7 @@ AxiSymModel::PSret AxiSymModel::gen_point_3d()
   if (gen_firstime) {
 
 #ifdef DEBUG
-    orb = SphericalOrbit(this);
+    orb = SphericalOrbit(this->shared_from_this());
 #endif
 
     double tol = 1.0e-5;
@@ -741,7 +741,7 @@ AxiSymModel::PSret AxiSymModel::gen_point_3d_iso
     gen_lastr = r;
 
 #ifdef DEBUG
-    std::cout << "gen_point_3d_iso[" << ModelID << "]: " << rmin
+    std::cout << "gen_point_3d_iso[" << ModelID << "]: " << get_min_radius()
 	 << ", " << get_max_radius() << std::endl;
 #endif
 

--- a/src/ParticleFerry.cc
+++ b/src/ParticleFerry.cc
@@ -362,7 +362,6 @@ void ParticleFerry::BufferSend()
   MPI_Send(&buf[0],    totchar, MPI_CHAR, _to, 3, MPI_COMM_WORLD);
 #ifdef DEBUG
   cout << "ParticleFerry: process " << myid  << " send, tot=" << itotcount << endl;
-  bufferKeyCheck();
 #endif
   ibufcount = bufpos = 0;	// Reset counter and position
 }
@@ -378,6 +377,5 @@ void ParticleFerry::BufferRecv()
   MPI_Recv(&buf[0],    bufpos, MPI_CHAR, _from, 3, MPI_COMM_WORLD, &s);
 #ifdef DEBUG
   cout << "ParticleFerry: process " << myid  << " recv, tot=" << itotcount-1+ibufcount << endl;
-  bufferKeyCheck();
 #endif
 }

--- a/utils/Analysis/KDcyltest.cc
+++ b/utils/Analysis/KDcyltest.cc
@@ -42,6 +42,7 @@
 #include <map>
 
                                 // System libs
+#include <unistd.h>
 #include <sys/time.h>
 #include <sys/resource.h>
 

--- a/utils/Analysis/KL_cyl.cc
+++ b/utils/Analysis/KL_cyl.cc
@@ -45,6 +45,7 @@
 #include <Eigen/Eigen>
 
                                 // System libs
+#include <unistd.h>
 #include <sys/time.h>
 #include <sys/resource.h>
 

--- a/utils/Analysis/KL_sph.cc
+++ b/utils/Analysis/KL_sph.cc
@@ -45,6 +45,7 @@
 				// Progress barp
 #include <Progress.H>
                                 // System libs
+#include <unistd.h>
 #include <sys/time.h>
 #include <sys/resource.h>
 

--- a/utils/Analysis/cross_validation_cyl.cc
+++ b/utils/Analysis/cross_validation_cyl.cc
@@ -46,6 +46,7 @@
 #include <Progress.H>
 
                                 // System libs
+#include <unistd.h>
 #include <sys/time.h>
 #include <sys/resource.h>
 

--- a/utils/Analysis/cross_validation_cyl2.cc
+++ b/utils/Analysis/cross_validation_cyl2.cc
@@ -50,6 +50,7 @@
 #include <cxxopts.H>
 
                                 // System libs
+#include <unistd.h>
 #include <sys/time.h>
 #include <sys/resource.h>
 

--- a/utils/Analysis/cross_validation_sph.cc
+++ b/utils/Analysis/cross_validation_sph.cc
@@ -43,6 +43,7 @@
 
 
                                 // System libs
+#include <unistd.h>
 #include <sys/time.h>
 #include <sys/resource.h>
 

--- a/utils/Analysis/cross_validation_sph2.cc
+++ b/utils/Analysis/cross_validation_sph2.cc
@@ -46,6 +46,7 @@ using namespace std;
 
 
                                 // System libs
+#include <unistd.h>
 #include <sys/time.h>
 #include <sys/resource.h>
 

--- a/utils/Analysis/diskeof.cc
+++ b/utils/Analysis/diskeof.cc
@@ -52,6 +52,7 @@
 #include <cxxopts.H>		// Command-line parser
 
                                 // System libs
+#include <unistd.h>
 #include <sys/time.h>
 #include <sys/resource.h>
 

--- a/utils/Analysis/diskfreqs.cc
+++ b/utils/Analysis/diskfreqs.cc
@@ -38,6 +38,7 @@
 #include <string>
 
                                 // System libs
+#include <unistd.h>
 #include <sys/time.h>
 #include <sys/resource.h>
 

--- a/utils/Analysis/diskprof.cc
+++ b/utils/Analysis/diskprof.cc
@@ -43,6 +43,7 @@
 #include <yaml-cpp/yaml.h>	// YAML support
 
                                 // System libs
+#include <unistd.h>
 #include <sys/time.h>
 #include <sys/resource.h>
 

--- a/utils/Analysis/diskprof_coef.cc
+++ b/utils/Analysis/diskprof_coef.cc
@@ -42,6 +42,7 @@
 #include <yaml-cpp/yaml.h>	// YAML support
 
                                 // System libs
+#include <unistd.h>
 #include <sys/time.h>
 #include <sys/resource.h>
 

--- a/utils/Analysis/gas2dcyl.cc
+++ b/utils/Analysis/gas2dcyl.cc
@@ -40,6 +40,7 @@
 using namespace std;
 
                                 // System libs
+#include <unistd.h>
 #include <sys/time.h>
 #include <sys/resource.h>
 

--- a/utils/Analysis/haloprof.cc
+++ b/utils/Analysis/haloprof.cc
@@ -41,6 +41,7 @@
 using namespace std;
 
                                 // System libs
+#include <unistd.h>
 #include <sys/time.h>
 #include <sys/resource.h>
 

--- a/utils/Analysis/haloprof_coef.cc
+++ b/utils/Analysis/haloprof_coef.cc
@@ -40,6 +40,7 @@
 #include <cmath>
 
                                 // System libs
+#include <unistd.h>
 #include <sys/time.h>
 #include <sys/resource.h>
 

--- a/utils/Analysis/mssaprof_disk.cc
+++ b/utils/Analysis/mssaprof_disk.cc
@@ -41,6 +41,7 @@
 #include <yaml-cpp/yaml.h>	// YAML support
 
                                 // System libs
+#include <unistd.h>
 #include <sys/time.h>
 #include <sys/resource.h>
 

--- a/utils/Analysis/mssaprof_halo.cc
+++ b/utils/Analysis/mssaprof_halo.cc
@@ -41,6 +41,7 @@
 #include <set>
 
                                 // System libs
+#include <unistd.h>
 #include <sys/time.h>
 #include <sys/resource.h>
 

--- a/utils/Analysis/pspbox.cc
+++ b/utils/Analysis/pspbox.cc
@@ -40,6 +40,7 @@
 using namespace std;
 
                                 // System libs
+#include <unistd.h>
 #include <sys/time.h>
 #include <sys/resource.h>
 

--- a/utils/Analysis/psphisto.cc
+++ b/utils/Analysis/psphisto.cc
@@ -39,6 +39,7 @@
 #include <cmath>
 
                                 // System libs
+#include <unistd.h>
 #include <sys/time.h>
 #include <sys/resource.h>
 

--- a/utils/Analysis/slabprof.cc
+++ b/utils/Analysis/slabprof.cc
@@ -37,6 +37,7 @@
 #include <string>
 
                                 // System libs
+#include <unistd.h>
 #include <sys/time.h>
 #include <sys/resource.h>
 

--- a/utils/Analysis/sphprof.cc
+++ b/utils/Analysis/sphprof.cc
@@ -39,6 +39,7 @@
 #include <memory>
 
                                 // System libs
+#include <unistd.h>
 #include <sys/time.h>
 #include <sys/resource.h>
 

--- a/utils/ICs/initial2d.cc
+++ b/utils/ICs/initial2d.cc
@@ -495,7 +495,7 @@ main(int ac, char **av)
   std::cout << "Processor " << myid << ": n_particlesH=" << n_particlesH
 	    << std::endl
 	    << "Processor " << myid << ": n_particlesD=" << n_particlesD
-	    << std::endl
+	    << std::endl;
 #endif
 
   if (nhalo + ndisk <= 0) {


### PR DESCRIPTION
This PR brings code in `ifdef DEBUG` blocks up to date with the current `devel` code.  The main changes are:

1. Missing `unistd.h` header for Unix `sleep()` used for debugging
2. Variable name changes in `orbit` for energy and kappa variables
3. A missing semicolon

Despite the number of files involved, this is a rather minor update.