### PR TITLE
Scope functions and variables so that static libraries build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ project(
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 # Compiler flags.  Not all tested thoroughly...
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/include/Sutils.H
+++ b/include/Sutils.H
@@ -9,7 +9,7 @@
 #include <locale>
 
 //! Split string on a character delimiter
-std::vector<std::string> str_split(const std::string& s, char delimiter)
+static inline std::vector<std::string> str_split(const std::string& s, char delimiter)
 {
   std::vector<std::string> tokens;
   std::string token;
@@ -21,7 +21,7 @@ std::vector<std::string> str_split(const std::string& s, char delimiter)
 }
 
 //! Return a lower case copy
-std::string str_to_lower(const std::string& s)
+static inline std::string str_to_lower(const std::string& s)
 {
   std::string d(s);
   std::for_each(d.begin(), d.end(), [](char & c){ c = std::tolower(c); });
@@ -30,7 +30,7 @@ std::string str_to_lower(const std::string& s)
 }
 
 //! Return an upper case copy
-std::string str_to_upper(const std::string& s)
+static inline std::string str_to_upper(const std::string& s)
 {
   std::string d(s);
   std::for_each(d.begin(), d.end(), [](char & c){ c = std::toupper(c); });

--- a/include/fpetrap.h
+++ b/include/fpetrap.h
@@ -32,7 +32,7 @@ static void (*oldhandler)(int);	// keep a reference to the initial value
    Turns on exceptions for invalid, div by zero and overflow, other  
    bits default.  This will only work for x86 architecture.
  */
-void set_fpu_handler(void)
+static void set_fpu_handler(void)
 {
 #ifdef HAVE_FPU_CONTROL_H 
 				// Set control flag (see fpu_control.h)

--- a/utils/PhaseSpace/psp2bess.cc
+++ b/utils/PhaseSpace/psp2bess.cc
@@ -31,14 +31,6 @@
 
 #include <mpi.h>
 
-//
-// MPI variables
-//
-int numprocs, proc_namelen;
-char processor_name[MPI_MAX_PROCESSOR_NAME];
-
-
-
 //! Coefficient file header
 struct BessCoefHeader
 {

--- a/utils/PhaseSpace/psp2interp.cc
+++ b/utils/PhaseSpace/psp2interp.cc
@@ -25,12 +25,6 @@ using namespace std;
 #include <Grid2D.H>
 #include <PSP.H>
 
-//
-// MPI variables
-//
-int numprocs, proc_namelen;
-char processor_name[MPI_MAX_PROCESSOR_NAME];
-
 int
 main(int ac, char **av)
 {

--- a/utils/PhaseSpace/psp2lagu.cc
+++ b/utils/PhaseSpace/psp2lagu.cc
@@ -31,12 +31,6 @@
 
 #include <mpi.h>
 
-//
-// MPI variables
-//
-int numprocs, proc_namelen;
-char processor_name[MPI_MAX_PROCESSOR_NAME];
-
 //! Generate orthonormal Laguerre functions
 class Laguerre
 {


### PR DESCRIPTION
Without these changes, I cannot build when `CMakeLists.txt` is modified to have
```cmake
option(BUILD_SHARED_LIBS "Build using shared libraries" OFF)
```
The changes are:

1. Add `static` and/or `inline` to functions defined in header files so that they are not publicly instantiated in multiple object files.
2. Remove definitions of global variables `numprocs`, `proc_namelen`, and `processor_name` from several files so that they do not duplicate nor hide those defined in `exputil/localmpi.cc`.

Note: with these changes, the build still works when I leave `CMakeLists.txt` with
```cmake
option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
```
