### PR TITLE
cmake: add more headers used from public interface

### DIFF
--- a/expui/CMakeLists.txt
+++ b/expui/CMakeLists.txt
@@ -84,6 +84,19 @@ target_sources(expui PUBLIC FILE_SET HEADERS
 	${CMAKE_CURRENT_SOURCE_DIR}/../include/massmodel.H
 	${CMAKE_CURRENT_SOURCE_DIR}/../include/interp.H
 	${CMAKE_CURRENT_SOURCE_DIR}/../include/orbit.H
+	${CMAKE_CURRENT_SOURCE_DIR}/../include/StringTok.H
+	${CMAKE_CURRENT_SOURCE_DIR}/../include/OrthoFunction.H
+	${CMAKE_CURRENT_SOURCE_DIR}/../include/gaussQ.H
+	${CMAKE_CURRENT_SOURCE_DIR}/../include/PseudoAccel.H
+	${CMAKE_CURRENT_SOURCE_DIR}/../include/QuadLS.H
+	${CMAKE_CURRENT_SOURCE_DIR}/../include/MonotCubicInterpolator.H
+	${CMAKE_CURRENT_SOURCE_DIR}/../include/QPDistF.H
+	${CMAKE_CURRENT_SOURCE_DIR}/../include/DiskWithHalo.H
+	${CMAKE_CURRENT_SOURCE_DIR}/../include/EmpCyl2d.H
+	${CMAKE_CURRENT_SOURCE_DIR}/../include/EXPmath.H
+	${CMAKE_CURRENT_SOURCE_DIR}/../include/libvars.H
+	${CMAKE_CURRENT_SOURCE_DIR}/../include/Timer.H
+	${CMAKE_CURRENT_SOURCE_DIR}/../include/coef.H
 )
 
 install(TARGETS expui FILE_SET HEADERS DESTINATION include/EXP)


### PR DESCRIPTION
As requested in #170. With these headers, Gala-EXP builds and runs against just the install directory.

I noticed that some headers, like `StringTok.H`, appear to be included in public headers, like `ParticleReader.H`, but not actually used there. In other words, I think we might be able to reduce the footprint of installed headers by moving "internal" includes to the `.cc` files rather than the `.H` files.

I just lumped all the new headers into the existing list of `expui` headers, but I think some of them technically apply to `exputil` rather than `expui`. It seemed like there were already headers for both in this list, though.

Also, most of the headers seem to be including each other using system-include style (`<>` instead of `""`), e.g. `ParticleReader.H` has `#include <Particle.H>`. System includes will not search the current directory, so this means we need to add two paths to the include path: `EXP/install/include` and `EXP/install/include/EXP`. I think the usual style would be to use double-quote includes for your own project's headers; then we could just use the former include path.