### PR TITLE
BiorthBasis: use Eigen::Ref for getAccel inputs

### DIFF
--- a/expui/BiorthBasis.H
+++ b/expui/BiorthBasis.H
@@ -195,9 +195,9 @@ namespace BasisClasses
 
     //! Evaluate acceleration in Cartesian coordinates in centered
     //! coordinate system for a collections of points
-    virtual RowMatrixXd& getAccel(Eigen::VectorXd& x,
-				  Eigen::VectorXd& y,
-				  Eigen::VectorXd& z)
+    virtual RowMatrixXd& getAccel(Eigen::Ref<const Eigen::VectorXd> x,
+				  Eigen::Ref<const Eigen::VectorXd> y,
+				  Eigen::Ref<const Eigen::VectorXd> z)
     {
       // Sanity check
       if (x.size() != y.size() || x.size() != z.size())
@@ -216,7 +216,7 @@ namespace BasisClasses
 
     //! Evaluate acceleration in Cartesian coordinates in centered
     //! coordinate system for a collections of points
-    virtual RowMatrixXd& getAccel(RowMatrixXd& pos)
+    virtual RowMatrixXd& getAccel(Eigen::Ref<const RowMatrixXd> pos)
     {
       // Sanity check
       if (pos.cols() != 3)

--- a/pyEXP/BasisWrappers.cc
+++ b/pyEXP/BasisWrappers.cc
@@ -1370,7 +1370,7 @@ void BasisFactoryClasses(py::module &m)
          __call__       : same as getFields() but provides field labels in a tuple
          )",
 	 py::arg("x"), py::arg("y"), py::arg("z"))
-    .def("getAccel", py::overload_cast<Eigen::VectorXd&, Eigen::VectorXd&, Eigen::VectorXd&>(&BasisClasses::BiorthBasis::getAccel),
+    .def("getAccel", py::overload_cast<Eigen::Ref<const Eigen::VectorXd>, Eigen::Ref<const Eigen::VectorXd>, Eigen::Ref<const Eigen::VectorXd>>(&BasisClasses::BiorthBasis::getAccel),
 	 R"(
          Return the acceleration for a given cartesian position
 
@@ -1394,7 +1394,7 @@ void BasisFactoryClasses(py::module &m)
          __call__       : same as getFields() but provides field labels in a tuple
          )",
 	 py::arg("x"), py::arg("y"), py::arg("z"))
-    .def("getAccel", py::overload_cast<RowMatrixXd&>(&BasisClasses::BiorthBasis::getAccel),
+    .def("getAccel", py::overload_cast<Eigen::Ref<const RowMatrixXd>>(&BasisClasses::BiorthBasis::getAccel),
 	 R"(
          Return the acceleration for an array of cartesian positions
 
@@ -1414,7 +1414,7 @@ void BasisFactoryClasses(py::module &m)
          __call__       : same as getFields() but provides field labels in a tuple
          )",
 	 py::arg("pos"))
-    .def("getAccelArray", py::overload_cast<Eigen::VectorXd&, Eigen::VectorXd&, Eigen::VectorXd&>(&BasisClasses::BiorthBasis::getAccel),
+    .def("getAccelArray", py::overload_cast<Eigen::Ref<const Eigen::VectorXd>, Eigen::Ref<const Eigen::VectorXd>, Eigen::Ref<const Eigen::VectorXd>>(&BasisClasses::BiorthBasis::getAccel),
 	 R"(
          Return the acceleration for a given cartesian position
 


### PR DESCRIPTION
In Gala, we have raw pointers and want to call the array overload for `getAccel`, so we're using `Eigen::Map` like so:

```c++
  Eigen::Map<Eigen::VectorXd> eigen_x(q.x, N);
  Eigen::Map<Eigen::VectorXd> eigen_y(q.y, N);
  Eigen::Map<Eigen::VectorXd> eigen_z(q.z, N);

  auto& allaccel = exp_state->basis->getAccel(eigen_x, eigen_y, eigen_z);
```

This currently doesn't work because the `getAccel` args must be `VectorXd`, not `Map`. This PR changes the API to accept `Map`s by changing the input types to `Eigen::Ref<const Eigen::VectorXd>`.