### PR TITLE
pyEXP: add get_shared_ptr_capsule() to BiorthBasis and Coefs

### DIFF
--- a/pyEXP/BasisWrappers.cc
+++ b/pyEXP/BasisWrappers.cc
@@ -1561,7 +1561,29 @@ void BasisFactoryClasses(py::module &m)
          Returns
          -------
          None
-         )", py::arg("coefs"));
+         )", py::arg("coefs"))
+    .def("get_shared_ptr_capsule", [](const std::shared_ptr<BasisClasses::BiorthBasis> &self) -> py::capsule {
+      return py::capsule(
+        new std::shared_ptr(self),
+        "BiorthBasis_shared_ptr",
+        [](void *v) { delete static_cast<std::shared_ptr<BasisClasses::BiorthBasis> *>(v); }
+      );
+    },
+    R"(
+        Get a capsule containing a shared pointer to the BiorthBasis instance.
+
+        Returns
+        -------
+        capsule: PyCapsule
+            A PyCapsule containing a shared pointer to the BiorthBasis instance with
+            the name "BiorthBasis_shared_ptr".
+
+        Notes
+        -----
+        This can be used to pass the BiorthBasis instance to non-Pybind11 C extensions
+        in a lifetime-safe manner.
+        )"
+    );
 
   py::class_<BasisClasses::Cylindrical, std::shared_ptr<BasisClasses::Cylindrical>, PyCylindrical, BasisClasses::BiorthBasis>(m, "Cylindrical")
     .def(py::init<const std::string&>(),

--- a/pyEXP/CoefWrappers.cc
+++ b/pyEXP/CoefWrappers.cc
@@ -1347,7 +1347,29 @@ void CoefficientClasses(py::module &m) {
                 --------
                 addcoef : add coefficient structures to an existing coefficieint container
                 )",
-		py::arg("coef"), py::arg("name")="");
+		py::arg("coef"), py::arg("name")="")
+    .def("get_shared_ptr_capsule", [](const std::shared_ptr<CoefClasses::Coefs> &self) -> py::capsule {
+      return py::capsule(
+        new std::shared_ptr(self),
+        "Coefs_shared_ptr",
+        [](void *v) { delete static_cast<std::shared_ptr<CoefClasses::Coefs> *>(v); }
+      );
+    },
+    R"(
+        Get a capsule containing a shared pointer to the Coefs instance.
+
+        Returns
+        -------
+        capsule: PyCapsule
+            A PyCapsule containing a shared pointer to the Coefs instance with
+            the name "Coefs_shared_ptr".
+
+        Notes
+        -----
+        This can be used to pass the Coefs instance to non-Pybind11 C extensions
+        in a lifetime-safe manner.
+        )"
+    );
 
   py::class_<CoefClasses::SphCoefs, std::shared_ptr<CoefClasses::SphCoefs>, PySphCoefs, CoefClasses::Coefs>
     (m, "SphCoefs", "Container for spherical coefficients")


### PR DESCRIPTION
I've been working on how to let Gala accept pyEXP objects, and this is the solution I've come up with. The basic question is how to pass a pybind11 object to Cython code (and, for extra credit, maintain lifetime safety while doing so). Neither library knows about the other, so it seems we need a way to get a pointer (ideally smart) to the wrapped C++ object that we can pass to Cython. Pybind11 doesn't provide any functionality to get this pointer from Python as far as I can tell, but it will automatically cast such an object to a smart pointer when passing it to a pybind11 function. So this PR adds a method to `BiorthBasis` and `Coefs` that simply returns a pointer to a new `shared_ptr` instance, copy-constructed from the `shared_ptr` that pybind11 gives us. This increases the refcount on the managed C++ instance and gives us a smart pointer to pass to Cython.

The alternative to adding pyEXP support for this would be to write these methods as pybind11 functions in Gala. That would require adding pybind11 as a dependency to Gala, though, which I think we would like to avoid. But it's an (untested) option if you'd rather not add this to EXP.

In detail, these pyEXP methods return [PyCapsule](https://docs.python.org/3/extending/extending.html#using-capsules) objects that wrap the pointer to the new `shared_ptr` instance. This is a Python object that we can easily pass from pybind11 to Cython and handles the cleanup of the `shared_ptr` itself. So, as long as the Cython code copy-constructs its own `shared_ptr` rather than using the encapsulated pointer directly, this scheme should be lifetime and memory safe.

CC @adrn 