### PR TITLE
BUG: Depend upon Python / pybind11 only if requested

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,7 @@ if(ENABLE_MINIMAL)
   set(ENABLE_UTILS OFF)
   set(ENABLE_TESTS OFF)
 endif()
-  
+
 # Metaflag for pyEXP only
 
 if(ENABLE_PYEXP_ONLY)
@@ -86,7 +86,7 @@ if(ENABLE_PYEXP_ONLY)
   set(ENABLE_UTILS OFF)
   set(ENABLE_TESTS OFF)
 endif()
-  
+
 # Set mpirun launcher for CTest
 
 set(EXP_MPI_LAUNCH "mpirun" CACHE STRING "Command to run an MPI application (for unit tests only)")
@@ -297,13 +297,13 @@ if(ENABLE_TESTS)
   add_subdirectory(tests)
 endif()
 
-# try to find pybind11 and build wrapper python module
-find_package(Python3 COMPONENTS Interpreter Development)
-message(STATUS "python3 include dirs: ${Python3_INCLUDE_DIRS}")
-if(Python3_FOUND)
-  set(HAVE_PYTHON3 TRUE)
-else()
-  if(ENABLE_PYEXP)
+if(ENABLE_PYEXP)
+  # try to find pybind11 and build wrapper python module
+  find_package(Python3 COMPONENTS Interpreter Development)
+  message(STATUS "python3 include dirs: ${Python3_INCLUDE_DIRS}")
+  if(Python3_FOUND)
+    set(HAVE_PYTHON3 TRUE)
+  else()
     message(FATAL_ERROR "You asked for pyEXP but I cannot find a Python3 environment. Please make Python3 available or disable pyEXP. CMake will exit." )
   endif()
 endif()
@@ -404,4 +404,3 @@ set(CMAKE_CXX_FLAGS_UBSAN
 # from the same source.
 configure_file(${CMAKE_SOURCE_DIR}/config_cmake.h_in ${CMAKE_BINARY_DIR}/config_exp.h)
 include_directories(${PROJECT_BINARY_DIR})
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,7 @@ if(ENABLE_MINIMAL)
   set(ENABLE_UTILS OFF)
   set(ENABLE_TESTS OFF)
 endif()
-  
+
 # Metaflag for pyEXP only
 
 if(ENABLE_PYEXP_ONLY)
@@ -86,7 +86,7 @@ if(ENABLE_PYEXP_ONLY)
   set(ENABLE_UTILS OFF)
   set(ENABLE_TESTS OFF)
 endif()
-  
+
 # Set mpirun launcher for CTest
 
 set(EXP_MPI_LAUNCH "mpirun" CACHE STRING "Command to run an MPI application (for unit tests only)")
@@ -298,13 +298,13 @@ if(ENABLE_TESTS)
   add_subdirectory(tests)
 endif()
 
-# try to find pybind11 and build wrapper python module
-find_package(Python3 COMPONENTS Interpreter Development)
-message(STATUS "python3 include dirs: ${Python3_INCLUDE_DIRS}")
-if(Python3_FOUND)
-  set(HAVE_PYTHON3 TRUE)
-else()
-  if(ENABLE_PYEXP)
+if(ENABLE_PYEXP)
+  # try to find pybind11 and build wrapper python module
+  find_package(Python3 COMPONENTS Interpreter Development)
+  message(STATUS "python3 include dirs: ${Python3_INCLUDE_DIRS}")
+  if(Python3_FOUND)
+    set(HAVE_PYTHON3 TRUE)
+  else()
     message(FATAL_ERROR "You asked for pyEXP but I cannot find a Python3 environment. Please make Python3 available or disable pyEXP. CMake will exit." )
   endif()
 endif()
@@ -405,4 +405,3 @@ set(CMAKE_CXX_FLAGS_UBSAN
 # from the same source.
 configure_file(${CMAKE_SOURCE_DIR}/config_cmake.h_in ${CMAKE_BINARY_DIR}/config_exp.h)
 include_directories(${PROJECT_BINARY_DIR})
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,7 @@ option(ENABLE_TESTS "Enable build tests for EXP, pyEXP and helpers" ON)
 option(ENABLE_MINIMAL "Compile EXP support libraries only" OFF)
 option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
 option(BUILD_DOCS "Build documentation" OFF)
+option(DISABLE_PYTHON "Disable the Python development environment" OFF)
 
 # Metaflag for minimal build
 
@@ -298,13 +299,15 @@ if(ENABLE_TESTS)
   add_subdirectory(tests)
 endif()
 
-if(ENABLE_PYEXP)
-  # try to find pybind11 and build wrapper python module
+# try to find pybind11 and build wrapper python module
+if (NOT DISABLE_PYTHON)
   find_package(Python3 COMPONENTS Interpreter Development)
-  message(STATUS "python3 include dirs: ${Python3_INCLUDE_DIRS}")
-  if(Python3_FOUND)
-    set(HAVE_PYTHON3 TRUE)
-  else()
+endif()
+message(STATUS "python3 include dirs: ${Python3_INCLUDE_DIRS}")
+if(Python3_FOUND)
+  set(HAVE_PYTHON3 TRUE)
+else()
+  if(ENABLE_PYEXP)
     message(FATAL_ERROR "You asked for pyEXP but I cannot find a Python3 environment. Please make Python3 available or disable pyEXP. CMake will exit." )
   endif()
 endif()

--- a/exputil/DiskDensityFunc.cc
+++ b/exputil/DiskDensityFunc.cc
@@ -1,3 +1,4 @@
+#include <stdexcept>
 #include "DiskDensityFunc.H"
 
 #ifdef HAVE_PYTHON3
@@ -38,7 +39,7 @@ DiskDensityFunc::DiskDensityFunc(const std::string& modulename,
 				 const std::string& funcname)
   : funcname(funcname)
 {
-  throw std::runtime_error("DiskDensityFunc: you environoment does not have Python3 support.  Use a built-in density target or install Python3 and recompile");
+  throw std::runtime_error("DiskDensityFunc: your environoment does not have Python3 support.  Use a built-in density target or install Python3 and recompile");
 }
 
 DiskDensityFunc::~DiskDensityFunc()

--- a/exputil/DiskDensityFunc.cc
+++ b/exputil/DiskDensityFunc.cc
@@ -1,4 +1,3 @@
-#include <stdexcept>
 #include "DiskDensityFunc.H"
 
 #ifdef HAVE_PYTHON3

--- a/include/DiskDensityFunc.H
+++ b/include/DiskDensityFunc.H
@@ -2,9 +2,11 @@
 #define _DiskDensityFunc_H_
 
 #include <functional>
+#include <string>
 
 #include "config_exp.h"
 
+#ifdef HAVE_PYTHON3
 #include <pybind11/pybind11.h>
 #include <pybind11/embed.h>
 
@@ -26,12 +28,14 @@
         a = 1.0                            # Scale radius
         h = 0.2                            # Scale height
         f = math.exp(-0.5*math.fabs(z)/h)  # Prevent overflows
-        sech = 2.0*f / (1.0 + f*f)         # 
+        sech = 2.0*f / (1.0 + f*f)         #
         return math.exp(-R/a)*sech*sech/(8*math.pi*h*a*a)
-	
+
     --------------------------cut here--------------------------------
 
  */
+#endif
+
 class __attribute__((visibility("default")))
 DiskDensityFunc
 {

--- a/include/DiskDensityFunc.H
+++ b/include/DiskDensityFunc.H
@@ -2,11 +2,9 @@
 #define _DiskDensityFunc_H_
 
 #include <functional>
-#include <string>
 
 #include "config_exp.h"
 
-#ifdef HAVE_PYTHON3
 #include <pybind11/pybind11.h>
 #include <pybind11/embed.h>
 
@@ -28,14 +26,12 @@
         a = 1.0                            # Scale radius
         h = 0.2                            # Scale height
         f = math.exp(-0.5*math.fabs(z)/h)  # Prevent overflows
-        sech = 2.0*f / (1.0 + f*f)         #
+        sech = 2.0*f / (1.0 + f*f)         # 
         return math.exp(-R/a)*sech*sech/(8*math.pi*h*a*a)
-
+	
     --------------------------cut here--------------------------------
 
  */
-#endif
-
 class __attribute__((visibility("default")))
 DiskDensityFunc
 {

--- a/include/DiskDensityFunc.H
+++ b/include/DiskDensityFunc.H
@@ -2,11 +2,15 @@
 #define _DiskDensityFunc_H_
 
 #include <functional>
+#include <stdexcept>
+#include <string>
 
 #include "config_exp.h"
 
+#ifdef HAVE_PYTHON3
 #include <pybind11/pybind11.h>
 #include <pybind11/embed.h>
+#endif
 
 /** Python disk-density function wrapper
 
@@ -26,9 +30,9 @@
         a = 1.0                            # Scale radius
         h = 0.2                            # Scale height
         f = math.exp(-0.5*math.fabs(z)/h)  # Prevent overflows
-        sech = 2.0*f / (1.0 + f*f)         # 
+        sech = 2.0*f / (1.0 + f*f)         #
         return math.exp(-R/a)*sech*sech/(8*math.pi*h*a*a)
-	
+
     --------------------------cut here--------------------------------
 
  */


### PR DESCRIPTION
When the cmake option `ENABLE_PYEXP` is `OFF`, we don't need Python or its `pybind11.h` include file.  However, currently, a build environment that has Python will try to include `pybind11.h` even when `ENABLE_PYEXP` is `OFF` and `pybind11.h` is not available.

The code change checks the value of `ENABLE_PYEXP` and, when it is `OFF`, the build does not try to use any part of Python, including `pybind11.h`.