### PR TITLE
Bug fix: update public headers in expui/CMakeLists.txt to fix gala compatibility

### DIFF
--- a/expui/CMakeLists.txt
+++ b/expui/CMakeLists.txt
@@ -100,6 +100,7 @@ target_sources(expui PUBLIC FILE_SET HEADERS
 	${CMAKE_CURRENT_SOURCE_DIR}/../include/libvars.H
 	${CMAKE_CURRENT_SOURCE_DIR}/../include/Timer.H
 	${CMAKE_CURRENT_SOURCE_DIR}/../include/coef.H
+	${CMAKE_CURRENT_SOURCE_DIR}/../include/Covariance.H
 )
 
 install(TARGETS expui FILE_SET HEADERS DESTINATION include/EXP)

--- a/expui/CMakeLists.txt
+++ b/expui/CMakeLists.txt
@@ -101,6 +101,7 @@ target_sources(expui PUBLIC FILE_SET HEADERS
 	${CMAKE_CURRENT_SOURCE_DIR}/../include/Timer.H
 	${CMAKE_CURRENT_SOURCE_DIR}/../include/coef.H
 	${CMAKE_CURRENT_SOURCE_DIR}/../include/Covariance.H
+	${CMAKE_CURRENT_SOURCE_DIR}/../include/ExpDeproj.H
 )
 
 install(TARGETS expui FILE_SET HEADERS DESTINATION include/EXP)


### PR DESCRIPTION
Attempting to build gala with EXP support using v7.9.3 failed with errors stating the build could not find the header files Covariance.H and ExpDeproj.H. 

Per @The9Cat , added these header files to expui/CmakeLists.txt. This fixes the issue and allows gala to be built with EXP 7.9.3.