### PR TITLE
Update for consistency with Gala

### DIFF
--- a/expui/BasisFactory.H
+++ b/expui/BasisFactory.H
@@ -197,10 +197,16 @@ namespace BasisClasses
 	       const Coord ctype=Coord::Spherical);
     
     //! Evaluate fields at a point
+    //! @note API change in v7.10.3: Added 'origin' parameter (default=false).
+    //!       This is an ABI-breaking change for external C++ code that
+    //!       subclasses Basis or calls these methods via vtable.
     virtual std::vector<double> getFields(double x, double y, double z,
 					  bool origin=false);
     
     //! Evaluate fields at a point for all coefficients sets
+    //! @note API change in v7.10.3: Added 'origin' parameter (default=false).
+    //!       This is an ABI-breaking change for external C++ code that
+    //!       subclasses Basis or calls these methods via vtable.
     virtual std::tuple<std::map<std::string, Eigen::VectorXd>,
 		       Eigen::VectorXd> getFieldsCoefs
     (double x, double y, double z, std::shared_ptr<CoefClasses::Coefs> coefs,

--- a/expui/BasisFactory.H
+++ b/expui/BasisFactory.H
@@ -212,7 +212,7 @@ namespace BasisClasses
     (double x, double y, double z, std::shared_ptr<CoefClasses::Coefs> coefs,
      bool origin=false);
     
-    //! Evaluate fields at a point, and provide field lables
+    //! Evaluate fields at a point, and provide field labels
     virtual std::tuple<std::vector<double>, std::vector<std::string>>
     evaluate(double x, double y, double z)
     { return {getFields(x, y, z, true), getFieldLabels(coordinates)}; }

--- a/expui/BasisFactory.H
+++ b/expui/BasisFactory.H
@@ -197,20 +197,20 @@ namespace BasisClasses
 	       const Coord ctype=Coord::Spherical);
     
     //! Evaluate fields at a point
-    //! @note API change in v7.10.3: Added 'origin' parameter (default=false).
+    //! @note API change in v7.10.3: Added 'origin' parameter (default=true).
     //!       This is an ABI-breaking change for external C++ code that
     //!       subclasses Basis or calls these methods via vtable.
     virtual std::vector<double> getFields(double x, double y, double z,
-					  bool origin=false);
+					  bool origin=true);
     
     //! Evaluate fields at a point for all coefficients sets
-    //! @note API change in v7.10.3: Added 'origin' parameter (default=false).
+    //! @note API change in v7.10.3: Added 'origin' parameter (default=true).
     //!       This is an ABI-breaking change for external C++ code that
     //!       subclasses Basis or calls these methods via vtable.
     virtual std::tuple<std::map<std::string, Eigen::VectorXd>,
 		       Eigen::VectorXd> getFieldsCoefs
     (double x, double y, double z, std::shared_ptr<CoefClasses::Coefs> coefs,
-     bool origin=false);
+     bool origin=true);
     
     //! Evaluate fields at a point, and provide field lables
     virtual std::tuple<std::vector<double>, std::vector<std::string>>

--- a/expui/BasisFactory.H
+++ b/expui/BasisFactory.H
@@ -196,26 +196,28 @@ namespace BasisClasses
     operator()(double x1, double x2, double x3,
 	       const Coord ctype=Coord::Spherical);
     
-    //! Evaluate fields at a point
-    //! @note API change in v7.10.3: Added 'origin' parameter (default=true).
-    //!       This is an ABI-breaking change for external C++ code that
-    //!       subclasses Basis or calls these methods via vtable.
-    virtual std::vector<double> getFields(double x, double y, double z,
-					  bool origin=true);
+    //! Evaluate fields at a point in the expansion-origin frame
+    virtual std::vector<double> getFields(double x, double y, double z);
+
+    //! Evaluate fields at a point in the coefficient-origin frame
+    virtual std::vector<double> getFieldsOrigin(double x, double y, double z);
     
-    //! Evaluate fields at a point for all coefficients sets
-    //! @note API change in v7.10.3: Added 'origin' parameter (default=true).
-    //!       This is an ABI-breaking change for external C++ code that
-    //!       subclasses Basis or calls these methods via vtable.
+    //! Evaluate fields at a point for all coefficients sets in the
+    //! expansion-origin frame
     virtual std::tuple<std::map<std::string, Eigen::VectorXd>,
 		       Eigen::VectorXd> getFieldsCoefs
-    (double x, double y, double z, std::shared_ptr<CoefClasses::Coefs> coefs,
-     bool origin=true);
+    (double x, double y, double z, std::shared_ptr<CoefClasses::Coefs> coefs);
+
+    //! Evaluate fields at a point for all coefficients sets in the
+    //! coefficient-origin frame
+    virtual std::tuple<std::map<std::string, Eigen::VectorXd>,
+		       Eigen::VectorXd> getFieldsCoefsOrigin
+    (double x, double y, double z, std::shared_ptr<CoefClasses::Coefs> coefs);
     
     //! Evaluate fields at a point, and provide field labels
     virtual std::tuple<std::vector<double>, std::vector<std::string>>
     evaluate(double x, double y, double z)
-    { return {getFields(x, y, z, true), getFieldLabels(coordinates)}; }
+    { return {getFields(x, y, z), getFieldLabels(coordinates)}; }
     
     //! Retrieve the coefficients 
     virtual CoefClasses::CoefStrPtr getCoefficients()

--- a/expui/BasisFactory.H
+++ b/expui/BasisFactory.H
@@ -215,7 +215,7 @@ namespace BasisClasses
     //! Evaluate fields at a point, and provide field lables
     virtual std::tuple<std::vector<double>, std::vector<std::string>>
     evaluate(double x, double y, double z)
-    { return {getFields(x, y, z), getFieldLabels(coordinates)}; }
+    { return {getFields(x, y, z, true), getFieldLabels(coordinates)}; }
     
     //! Retrieve the coefficients 
     virtual CoefClasses::CoefStrPtr getCoefficients()

--- a/expui/BasisFactory.H
+++ b/expui/BasisFactory.H
@@ -197,17 +197,19 @@ namespace BasisClasses
 	       const Coord ctype=Coord::Spherical);
     
     //! Evaluate fields at a point
-    virtual std::vector<double> getFields(double x, double y, double z);
+    virtual std::vector<double> getFields(double x, double y, double z,
+					  bool origin=false);
     
     //! Evaluate fields at a point for all coefficients sets
     virtual std::tuple<std::map<std::string, Eigen::VectorXd>,
 		       Eigen::VectorXd> getFieldsCoefs
-    (double x, double y, double z, std::shared_ptr<CoefClasses::Coefs> coefs);
+    (double x, double y, double z, std::shared_ptr<CoefClasses::Coefs> coefs,
+     bool origin=false);
     
     //! Evaluate fields at a point, and provide field lables
     virtual std::tuple<std::vector<double>, std::vector<std::string>>
     evaluate(double x, double y, double z)
-    { return {getFields(x, y, z), getFieldLabels(coordinates)}; }
+    { return {getFields(x, y, z, true), getFieldLabels(coordinates)}; }
     
     //! Retrieve the coefficients 
     virtual CoefClasses::CoefStrPtr getCoefficients()

--- a/expui/BasisFactory.H
+++ b/expui/BasisFactory.H
@@ -209,7 +209,7 @@ namespace BasisClasses
     //! Evaluate fields at a point, and provide field lables
     virtual std::tuple<std::vector<double>, std::vector<std::string>>
     evaluate(double x, double y, double z)
-    { return {getFields(x, y, z, true), getFieldLabels(coordinates)}; }
+    { return {getFields(x, y, z), getFieldLabels(coordinates)}; }
     
     //! Retrieve the coefficients 
     virtual CoefClasses::CoefStrPtr getCoefficients()

--- a/expui/BasisFactory.cc
+++ b/expui/BasisFactory.cc
@@ -228,14 +228,21 @@ namespace BasisClasses
     };
   }
     
-  std::vector<double> Basis::getFields(double x, double y, double z)
+  std::vector<double> Basis::getFields(double x, double y, double z,
+				       bool origin)
   {
+    if (not origin) {
+      x -= coefctr(0);
+      y -= coefctr(1);
+      z -= coefctr(2);
+    }
     return crt_eval(x, y, z);
   }
     
   std::tuple<std::map<std::string, Eigen::VectorXd>, Eigen::VectorXd>
   Basis::getFieldsCoefs
-  (double x, double y, double z, std::shared_ptr<CoefClasses::Coefs> coefs)
+  (double x, double y, double z, std::shared_ptr<CoefClasses::Coefs> coefs,
+   bool origin)
   {
     // Python dictonary for return
     std::map<std::string, Eigen::VectorXd> ret;
@@ -249,9 +256,19 @@ namespace BasisClasses
 
     // Make the return dictionary of arrays
     for (int i=0; i<times.size(); i++) {
+      // Load the coefficients for the current time
       set_coefs(coefs->getCoefStruct(times[i]));
+
+      // Apply centering if requested
+      if (not origin) {
+	x -= coefctr(0);
+	y -= coefctr(1);
+	z -= coefctr(2);
+      }
+      
       // The field evaluation
       auto v = crt_eval(x, y, z); 
+
       // Pack the fields into the dictionary
       for (int j=0; j<fields.size(); j++) ret[fields[j]][i] = v[j];
     }

--- a/expui/BasisFactory.cc
+++ b/expui/BasisFactory.cc
@@ -259,15 +259,19 @@ namespace BasisClasses
       // Load the coefficients for the current time
       set_coefs(coefs->getCoefStruct(times[i]));
 
-      // Apply centering if requested
+      // Apply centering if requested without modifying the input
+      // coordinates so each time step is evaluated from the same point.
+      auto xc = x;
+      auto yc = y;
+      auto zc = z;
       if (not origin) {
-	x -= coefctr(0);
-	y -= coefctr(1);
-	z -= coefctr(2);
+	xc -= coefctr(0);
+	yc -= coefctr(1);
+	zc -= coefctr(2);
       }
       
       // The field evaluation
-      auto v = crt_eval(x, y, z); 
+      auto v = crt_eval(xc, yc, zc); 
 
       // Pack the fields into the dictionary
       for (int j=0; j<fields.size(); j++) ret[fields[j]][i] = v[j];

--- a/expui/BasisFactory.cc
+++ b/expui/BasisFactory.cc
@@ -228,21 +228,20 @@ namespace BasisClasses
     };
   }
     
-  std::vector<double> Basis::getFields(double x, double y, double z,
-				       bool origin)
+  std::vector<double> Basis::getFields(double x, double y, double z)
+  { return crt_eval(x, y, z); }
+
+  std::vector<double> Basis::getFieldsOrigin(double x, double y, double z)
   {
-    if (not origin) {
-      x -= coefctr(0);
-      y -= coefctr(1);
-      z -= coefctr(2);
-    }
+    x -= coefctr(0);
+    y -= coefctr(1);
+    z -= coefctr(2);
     return crt_eval(x, y, z);
   }
     
   std::tuple<std::map<std::string, Eigen::VectorXd>, Eigen::VectorXd>
   Basis::getFieldsCoefs
-  (double x, double y, double z, std::shared_ptr<CoefClasses::Coefs> coefs,
-   bool origin)
+  (double x, double y, double z, std::shared_ptr<CoefClasses::Coefs> coefs)
   {
     // Python dictonary for return
     std::map<std::string, Eigen::VectorXd> ret;
@@ -259,16 +258,42 @@ namespace BasisClasses
       // Load the coefficients for the current time
       set_coefs(coefs->getCoefStruct(times[i]));
 
-      double xc = x, yc = y, zc = z;
-      // Apply centering
-      if (not origin) {
-	xc -= coefctr(0);
-	yc -= coefctr(1);
-	zc -= coefctr(2);
-      }
-      
       // The field evaluation
-      auto v = crt_eval(xc, yc, zc); 
+      auto v = crt_eval(x, y, z); 
+
+      // Pack the fields into the dictionary
+      for (int j=0; j<fields.size(); j++) ret[fields[j]][i] = v[j];
+    }
+
+    // An attempt at an efficient return type for the time array
+    Eigen::VectorXd T =
+      Eigen::Map<Eigen::VectorXd, Eigen::Unaligned>(times.data(), times.size());
+
+    // Return the dictionary and the time array
+    return {ret, T};
+  }
+
+  std::tuple<std::map<std::string, Eigen::VectorXd>, Eigen::VectorXd>
+  Basis::getFieldsCoefsOrigin
+  (double x, double y, double z, std::shared_ptr<CoefClasses::Coefs> coefs)
+  {
+    // Python dictonary for return
+    std::map<std::string, Eigen::VectorXd> ret;
+
+    // Times for the coefficients
+    auto times  = coefs->Times();
+
+    // Initialize the dictionary/map
+    auto fields = getFieldLabels(coordinates);
+    for (auto s : fields) ret[s].resize(times.size());
+
+    // Make the return dictionary of arrays
+    for (int i=0; i<times.size(); i++) {
+      // Load the coefficients for the current time
+      set_coefs(coefs->getCoefStruct(times[i]));
+
+      // The field evaluation
+      auto v = getFieldsOrigin(x, y, z);
 
       // Pack the fields into the dictionary
       for (int j=0; j<fields.size(); j++) ret[fields[j]][i] = v[j];

--- a/expui/BasisFactory.cc
+++ b/expui/BasisFactory.cc
@@ -254,20 +254,21 @@ namespace BasisClasses
     auto fields = getFieldLabels(coordinates);
     for (auto s : fields) ret[s].resize(times.size());
 
-    // Apply centering
-    if (not origin) {
-      x -= coefctr(0);
-      y -= coefctr(1);
-      z -= coefctr(2);
-    }
-
     // Make the return dictionary of arrays
     for (int i=0; i<times.size(); i++) {
       // Load the coefficients for the current time
       set_coefs(coefs->getCoefStruct(times[i]));
 
+      double xc = x, yc = y, zc = z;
+      // Apply centering
+      if (not origin) {
+	xc -= coefctr(0);
+	yc -= coefctr(1);
+	zc -= coefctr(2);
+      }
+      
       // The field evaluation
-      auto v = crt_eval(x, y, z); 
+      auto v = crt_eval(xc, yc, zc); 
 
       // Pack the fields into the dictionary
       for (int j=0; j<fields.size(); j++) ret[fields[j]][i] = v[j];

--- a/expui/BasisFactory.cc
+++ b/expui/BasisFactory.cc
@@ -243,7 +243,7 @@ namespace BasisClasses
   Basis::getFieldsCoefs
   (double x, double y, double z, std::shared_ptr<CoefClasses::Coefs> coefs)
   {
-    // Python dictonary for return
+    // Python dictionary for return
     std::map<std::string, Eigen::VectorXd> ret;
 
     // Times for the coefficients
@@ -277,7 +277,7 @@ namespace BasisClasses
   Basis::getFieldsCoefsOrigin
   (double x, double y, double z, std::shared_ptr<CoefClasses::Coefs> coefs)
   {
-    // Python dictonary for return
+    // Python dictionary for return
     std::map<std::string, Eigen::VectorXd> ret;
 
     // Times for the coefficients

--- a/expui/BasisFactory.cc
+++ b/expui/BasisFactory.cc
@@ -254,24 +254,20 @@ namespace BasisClasses
     auto fields = getFieldLabels(coordinates);
     for (auto s : fields) ret[s].resize(times.size());
 
+    // Apply centering
+    if (not origin) {
+      x -= coefctr(0);
+      y -= coefctr(1);
+      z -= coefctr(2);
+    }
+
     // Make the return dictionary of arrays
     for (int i=0; i<times.size(); i++) {
       // Load the coefficients for the current time
       set_coefs(coefs->getCoefStruct(times[i]));
 
-      // Apply centering if requested without modifying the input
-      // coordinates so each time step is evaluated from the same point.
-      auto xc = x;
-      auto yc = y;
-      auto zc = z;
-      if (not origin) {
-	xc -= coefctr(0);
-	yc -= coefctr(1);
-	zc -= coefctr(2);
-      }
-      
       // The field evaluation
-      auto v = crt_eval(xc, yc, zc); 
+      auto v = crt_eval(x, y, z); 
 
       // Pack the fields into the dictionary
       for (int j=0; j<fields.size(); j++) ret[fields[j]][i] = v[j];

--- a/expui/BiorthBasis.cc
+++ b/expui/BiorthBasis.cc
@@ -1823,8 +1823,12 @@ namespace BasisClasses
     
     tdens = sl->accumulated_dens_eval(R, z, phi, tdens0);
 
-    double tpotx = tpotR*x/R - tpotp*y/R ;
-    double tpoty = tpotR*y/R + tpotp*x/R ;
+    double tpotx = 0.0;
+    double tpoty = 0.0;
+    if (R > 0.0) {
+      tpotx = tpotR*x/R - tpotp*y/R;
+      tpoty = tpotR*y/R + tpotp*x/R;
+    }
 
     // Apply G to forces on return
     acc << tpotx*G, tpoty*G, tpotz*G;

--- a/expui/BiorthBasis.cc
+++ b/expui/BiorthBasis.cc
@@ -818,6 +818,11 @@ namespace BasisClasses
   void Spherical::computeAccel(double x, double y, double z,
 			       Eigen::Ref<Eigen::Vector3d> acc)
   {
+    // Shift to center
+    x -= coefctr(0);
+    y -= coefctr(1);
+    z -= coefctr(2);
+
     // Get polar coordinates
     double R2    = x*x + y*y;
     double r2    = R2  + z*z;
@@ -1804,6 +1809,11 @@ namespace BasisClasses
   void Cylindrical::computeAccel(double x, double y, double z,
 				 Eigen::Ref<Eigen::Vector3d> acc)
   {
+    // Shift to center
+    x -= coefctr(0);
+    y -= coefctr(1);
+    z -= coefctr(2);
+
     double R = sqrt(x*x + y*y);
     double phi = atan2(y, x);
 
@@ -2481,6 +2491,11 @@ namespace BasisClasses
   void FlatDisk::computeAccel(double x, double y, double z, 
 			      Eigen::Ref<Eigen::Vector3d> acc)
   {
+    // Shift to center
+    x -= coefctr(0);
+    y -= coefctr(1);
+    z -= coefctr(2);
+
     // Get thread id
     int tid = omp_get_thread_num();
 
@@ -3270,6 +3285,11 @@ namespace BasisClasses
   void CBDisk::computeAccel(double x, double y, double z,
 			    Eigen::Ref<Eigen::Vector3d> acc)
   {
+    // Shift to center
+    x -= coefctr(0);
+    y -= coefctr(1);
+    z -= coefctr(2);
+
     // Get thread id
     int tid = omp_get_thread_num();
 
@@ -3756,6 +3776,11 @@ namespace BasisClasses
   void Slab::computeAccel(double x, double y, double z,
 			  Eigen::Ref<Eigen::Vector3d> acc)
   {
+    // Shift to center
+    x -= coefctr(0);
+    y -= coefctr(1);
+    z -= coefctr(2);
+
     // Loop indices
     //
     int ix, iy, iz;
@@ -4328,6 +4353,11 @@ namespace BasisClasses
   void Cube::computeAccel(double x, double y, double z,
 			  Eigen::Ref<Eigen::Vector3d> acc)
   {
+    // Shift to center
+    x -= coefctr(0);
+    y -= coefctr(1);
+    z -= coefctr(2);
+
     // Get thread id
     int tid = omp_get_thread_num();
 
@@ -4781,7 +4811,7 @@ namespace BasisClasses
       for (int k=0; k<3; k++) pp(k) = ps(n, k) - ctr(k);
       pp = rot * pp;
 
-      auto v = basis->getFields(pp(0), pp(1), pp(2));
+      auto v = basis->getFields(pp(0), pp(1), pp(2), true);
 
       // First 6 fields are density and potential, followed by acceleration
       for (int k=0; k<3; k++) accel(n, k) += v[6+k] - basis->pseudo(k);

--- a/expui/BiorthBasis.cc
+++ b/expui/BiorthBasis.cc
@@ -2584,8 +2584,12 @@ namespace BasisClasses
     zpot *= -G;
     ppot *= -G;
 
-    double potx = rpot*x/R - ppot*y/R;
-    double poty = rpot*y/R + ppot*x/R;
+    double potx = 0.0;
+    double poty = 0.0;
+    if (R > 0.0) {
+      potx = rpot*x/R - ppot*y/R;
+      poty = rpot*y/R + ppot*x/R;
+    }
 
     acc << potx, poty, zpot;
   }
@@ -3354,8 +3358,12 @@ namespace BasisClasses
     rpot *= -G;
     ppot *= -G;
 
-    double potx = rpot*x/R - ppot*y/R;
-    double poty = rpot*y/R + ppot*x/R;
+    double potx = 0.0;
+    double poty = 0.0;
+    if (R > 0.0) {
+      potx = rpot*x/R - ppot*y/R;
+      poty = rpot*y/R + ppot*x/R;
+    }
 
     acc << potx, poty, zpot;
   }

--- a/expui/BiorthBasis.cc
+++ b/expui/BiorthBasis.cc
@@ -1797,8 +1797,12 @@ namespace BasisClasses
     
     tdens = sl->accumulated_dens_eval(R, z, phi, tdens0);
 
-    double tpotx = tpotR*x/R - tpotp*y/R ;
-    double tpoty = tpotR*y/R + tpotp*x/R ;
+    double tpotx = 0.0;
+    double tpoty = 0.0;
+    if (R > 0.0) {
+      tpotx = tpotR*x/R - tpotp*y/R;
+      tpoty = tpotR*y/R + tpotp*x/R;
+    }
 
     return
       {tdens0, tdens - tdens0, tdens,
@@ -4823,7 +4827,7 @@ namespace BasisClasses
       for (int k=0; k<3; k++) pp(k) = ps(n, k) - ctr(k);
       pp = rot * pp;
 
-      auto v = basis->getFields(pp(0), pp(1), pp(2), true);
+      auto v = basis->getFields(pp(0), pp(1), pp(2));
 
       // First 6 fields are density and potential, followed by acceleration
       for (int k=0; k<3; k++) accel(n, k) += v[6+k] - basis->pseudo(k);

--- a/expui/CMakeLists.txt
+++ b/expui/CMakeLists.txt
@@ -97,11 +97,15 @@ target_sources(expui PUBLIC FILE_SET HEADERS
 	${CMAKE_CURRENT_SOURCE_DIR}/../include/DiskWithHalo.H
 	${CMAKE_CURRENT_SOURCE_DIR}/../include/EmpCyl2d.H
 	${CMAKE_CURRENT_SOURCE_DIR}/../include/EXPmath.H
+	${CMAKE_CURRENT_SOURCE_DIR}/../include/EXPversion.H
 	${CMAKE_CURRENT_SOURCE_DIR}/../include/libvars.H
 	${CMAKE_CURRENT_SOURCE_DIR}/../include/Timer.H
 	${CMAKE_CURRENT_SOURCE_DIR}/../include/coef.H
 	${CMAKE_CURRENT_SOURCE_DIR}/../include/Covariance.H
 	${CMAKE_CURRENT_SOURCE_DIR}/../include/ExpDeproj.H
+	${CMAKE_CURRENT_SOURCE_DIR}/../include/cudaUtil.cuH
+	${CMAKE_CURRENT_SOURCE_DIR}/../include/cudaParticle.cuH
+	${CMAKE_CURRENT_SOURCE_DIR}/../include/cudaMappingConstants.cuH	
 )
 
 install(TARGETS expui FILE_SET HEADERS DESTINATION include/EXP)

--- a/expui/CMakeLists.txt
+++ b/expui/CMakeLists.txt
@@ -97,7 +97,7 @@ target_sources(expui PUBLIC FILE_SET HEADERS
 	${CMAKE_CURRENT_SOURCE_DIR}/../include/DiskWithHalo.H
 	${CMAKE_CURRENT_SOURCE_DIR}/../include/EmpCyl2d.H
 	${CMAKE_CURRENT_SOURCE_DIR}/../include/EXPmath.H
-	${CMAKE_CURRENT_SOURCE_DIR}/../include/EXPversion.H
+	# ${CMAKE_CURRENT_SOURCE_DIR}/../include/EXPversion.H
 	${CMAKE_CURRENT_SOURCE_DIR}/../include/libvars.H
 	${CMAKE_CURRENT_SOURCE_DIR}/../include/Timer.H
 	${CMAKE_CURRENT_SOURCE_DIR}/../include/coef.H

--- a/include/BiorthCube.H
+++ b/include/BiorthCube.H
@@ -17,8 +17,9 @@
 #include <yaml-cpp/yaml.h>
 
 #if HAVE_LIBCUDA==1
-#include <cudaUtil.cuH>
-#include <cudaMappingConstants.cuH>
+#include "cudaUtil.cuH"
+#include "cudaParticle.cuH"
+#include "cudaMappingConstants.cuH"
 #endif
 
 // For reading and writing cache file
@@ -27,11 +28,6 @@
 #include <highfive/H5DataSet.hpp>
 #include <highfive/H5DataSpace.hpp>
 #include <highfive/H5Attribute.hpp>
-
-#if HAVE_LIBCUDA==1
-#include <cudaParticle.cuH>
-#include <cudaMappingConstants.cuH>
-#endif
 
 #include "EmpCyl2d.H"
 

--- a/include/BiorthCyl.H
+++ b/include/BiorthCyl.H
@@ -17,8 +17,9 @@
 #include <yaml-cpp/yaml.h>
 
 #if HAVE_LIBCUDA==1
-#include <cudaUtil.cuH>
-#include <cudaMappingConstants.cuH>
+#include "cudaUtil.cuH"
+#include "cudaParticle.cuH"
+#include "cudaMappingConstants.cuH"
 #endif
 
 // For reading and writing cache file
@@ -27,11 +28,6 @@
 #include <highfive/H5DataSet.hpp>
 #include <highfive/H5DataSpace.hpp>
 #include <highfive/H5Attribute.hpp>
-
-#if HAVE_LIBCUDA==1
-#include <cudaParticle.cuH>
-#include <cudaMappingConstants.cuH>
-#endif
 
 #include "EmpCyl2d.H"
 

--- a/include/EmpCylSL.H
+++ b/include/EmpCylSL.H
@@ -24,8 +24,8 @@
 #include "coef.H"
 
 #if HAVE_LIBCUDA==1
-#include <cudaParticle.cuH>
-#include <cudaMappingConstants.cuH>
+#include "cudaParticle.cuH"
+#include "cudaMappingConstants.cuH"
 #endif
 
 #include "libvars.H"

--- a/include/SLGridMP2.H
+++ b/include/SLGridMP2.H
@@ -19,8 +19,8 @@
 using namespace __EXP__;
 
 #if HAVE_LIBCUDA==1
-#include <cudaUtil.cuH>
-#include <cudaMappingConstants.cuH>
+#include "cudaUtil.cuH"
+#include "cudaMappingConstants.cuH"
 #endif
 
 

--- a/include/cudaMappingConstants.cuH
+++ b/include/cudaMappingConstants.cuH
@@ -1,9 +1,7 @@
-// -*- C++ -*-
-
 #ifndef CUDA_MAPPING_CONSTANTS_H
 #define CUDA_MAPPING_CONSTANTS_H
 
-#include <cudaUtil.cuH>
+#include "cudaUtil.cuH"
 
 struct cudaMappingConstants
 {
@@ -23,3 +21,5 @@ struct cudaMappingConstants
 };
 
 #endif
+
+// -*- C++ -*-

--- a/include/cudaParticle.cuH
+++ b/include/cudaParticle.cuH
@@ -1,5 +1,3 @@
-// -*- C++ -*-
-
 #ifndef PARTICLE_CUH
 #define PARTICLE_CUH
 
@@ -16,11 +14,9 @@
 #include <thrust/host_vector.h>
 #include <thrust/sort.h>
 
-#include <config_exp.h>
-
-#include <cudaUtil.cuH>
-
-#include <Particle.H>
+#include "config_exp.h"
+#include "cudaUtil.cuH"
+#include "Particle.H"
 
 //! Simplified particle structure for use in CUDA kernel code
 struct cudaParticle
@@ -125,3 +121,5 @@ struct cuPartToChange
 };
 
 #endif
+
+// -*- C++ -*-

--- a/pyEXP/BasisWrappers.cc
+++ b/pyEXP/BasisWrappers.cc
@@ -1574,7 +1574,7 @@ void BasisFactoryClasses(py::module &m)
 	 py::arg("x"), py::arg("y"), py::arg("z"))
     .def("getAccel", py::overload_cast<Eigen::Ref<const Eigen::VectorXd>, Eigen::Ref<const Eigen::VectorXd>, Eigen::Ref<const Eigen::VectorXd>>(&BasisClasses::BiorthBasis::getAccel),
 	 R"(
-         Return the acceleration for a given Cartesian position in the frame defined by the coeffients.
+         Return the acceleration for a given Cartesian position in the frame defined by the coefficients.
 
          Parameters
          ----------
@@ -1598,7 +1598,7 @@ void BasisFactoryClasses(py::module &m)
 	 py::arg("x"), py::arg("y"), py::arg("z"))
     .def("getAccel", py::overload_cast<Eigen::Ref<const RowMatrixXd>>(&BasisClasses::BiorthBasis::getAccel),
 	 R"(
-         Return the acceleration for an array of Cartesian positions in the frame defined by the coeffients.
+         Return the acceleration for an array of Cartesian positions in the frame defined by the coefficients.
 
          Parameters
          ----------
@@ -1618,7 +1618,7 @@ void BasisFactoryClasses(py::module &m)
 	 py::arg("pos"))
     .def("getAccelArray", py::overload_cast<Eigen::Ref<const Eigen::VectorXd>, Eigen::Ref<const Eigen::VectorXd>, Eigen::Ref<const Eigen::VectorXd>>(&BasisClasses::BiorthBasis::getAccel),
 	 R"(
-         Return the acceleration for a given Cartesian position in the frame defined by the coeffients.
+         Return the acceleration for a given Cartesian position in the frame defined by the coefficients.
 
          Parameters
          ----------

--- a/pyEXP/BasisWrappers.cc
+++ b/pyEXP/BasisWrappers.cc
@@ -330,52 +330,18 @@ void BasisFactoryClasses(py::module &m)
     // Inherit the constructors
     using BasisClasses::Basis::Basis;
 
-    std::vector<double> getFields(double x, double y, double z, bool origin) override
+    std::vector<double> getFields(double x, double y, double z) override
     {
-      pybind11::gil_scoped_acquire gil;
-      pybind11::function override_func =
-	pybind11::get_override(static_cast<const Basis*>(this), "getFields");
-      if (override_func) {
-	try {
-	  auto result = override_func(x, y, z, origin);
-	  return result.cast<std::vector<double>>();
-	} catch (pybind11::error_already_set& e) {
-	  if (e.matches(PyExc_TypeError)) {
-	    // Backward-compatible fallback for subclasses with 3-arg signature
-	    PyErr_Clear();
-	    auto result = override_func(x, y, z);
-	    return result.cast<std::vector<double>>();
-	  }
-	  throw;
-	}
-      }
-      return Basis::getFields(x, y, z, origin);
+      PYBIND11_OVERRIDE(std::vector<double>, Basis, getFields, x, y, z);
     }
 
     using FCReturn = std::tuple<std::map<std::string, Eigen::VectorXd>,
 				Eigen::VectorXd>;
 
     FCReturn getFieldsCoefs
-    (double x, double y, double z, CoefClasses::CoefsPtr coefs, bool origin) override
+    (double x, double y, double z, CoefClasses::CoefsPtr coefs) override
     {
-      pybind11::gil_scoped_acquire gil;
-      pybind11::function override_func =
-	pybind11::get_override(static_cast<const Basis*>(this), "getFieldsCoefs");
-      if (override_func) {
-	try {
-	  auto result = override_func(x, y, z, coefs, origin);
-	  return result.cast<FCReturn>();
-	} catch (pybind11::error_already_set& e) {
-	  if (e.matches(PyExc_TypeError)) {
-	    // Backward-compatible fallback for subclasses with 4-arg signature
-	    PyErr_Clear();
-	    auto result = override_func(x, y, z, coefs);
-	    return result.cast<FCReturn>();
-	  }
-	  throw;
-	}
-      }
-      return Basis::getFieldsCoefs(x, y, z, coefs, origin);
+      PYBIND11_OVERRIDE(FCReturn, Basis, getFieldsCoefs, x, y, z, coefs);
     }
     
     void accumulate(double x, double y, double z, double mass, unsigned long int indx) override {
@@ -468,22 +434,9 @@ void BasisFactoryClasses(py::module &m)
     // Inherit the constructors
     using FieldBasis::FieldBasis;
 
-    std::vector<double> getFields(double x, double y, double z, bool origin) override
+    std::vector<double> getFields(double x, double y, double z) override
     {
-      py::gil_scoped_acquire gil;
-      py::function override = py::get_override(static_cast<const FieldBasis *>(this), "getFields");
-
-      if (override) {
-        try {
-          return override(x, y, z, origin).cast<std::vector<double>>();
-        } catch (py::error_already_set &e) {
-          if (!e.matches(PyExc_TypeError)) throw;
-          e.clear();
-          return override(x, y, z).cast<std::vector<double>>();
-        }
-      }
-
-      return FieldBasis::getFields(x, y, z, origin);
+      PYBIND11_OVERRIDE(std::vector<double>, FieldBasis, getFields, x, y, z);
     }
 
     void accumulate(double m, double x, double y, double z,
@@ -608,17 +561,12 @@ void BasisFactoryClasses(py::module &m)
     // Inherit the constructors
     using Spherical::Spherical;
 
-    std::vector<double> getFields(double x, double y, double z, bool origin) override {
+    std::vector<double> getFields(double x, double y, double z) override {
       py::function override = py::get_override(static_cast<const Spherical*>(this), "getFields");
       if (override) {
-        try {
-          return py::cast<std::vector<double>>(override(x, y, z, origin));
-        } catch (py::error_already_set &e) {
-          if (!e.matches(PyExc_TypeError)) throw;
-        }
         return py::cast<std::vector<double>>(override(x, y, z));
       }
-      return Spherical::getFields(x, y, z, origin);
+      return Spherical::getFields(x, y, z);
     }
 
     void accumulate(double x, double y, double z, double mass, unsigned long int indx) override {
@@ -683,8 +631,8 @@ void BasisFactoryClasses(py::module &m)
     // Inherit the constructors
     using Cylindrical::Cylindrical;
 
-    std::vector<double> getFields(double x, double y, double z, bool origin) override {
-      PYBIND11_OVERRIDE(std::vector<double>, Cylindrical, getFields, x, y, z, origin);
+    std::vector<double> getFields(double x, double y, double z) override {
+      PYBIND11_OVERRIDE(std::vector<double>, Cylindrical, getFields, x, y, z);
     }
 
     void accumulate(double x, double y, double z, double mass, unsigned long int indx) override {
@@ -761,9 +709,9 @@ void BasisFactoryClasses(py::module &m)
     // Inherit the constructors
     using FlatDisk::FlatDisk;
 
-    std::vector<double> getFields(double x, double y, double z, bool origin) override
+    std::vector<double> getFields(double x, double y, double z) override
     {
-      PYBIND11_OVERRIDE(std::vector<double>, FlatDisk, getFields, x, y, z, origin);
+      PYBIND11_OVERRIDE(std::vector<double>, FlatDisk, getFields, x, y, z);
     }
 
     void accumulate(double x, double y, double z, double mass, unsigned long int indx) override
@@ -843,20 +791,9 @@ void BasisFactoryClasses(py::module &m)
     // Inherit the constructors
     using CBDisk::CBDisk;
 
-    std::vector<double> getFields(double x, double y, double z, bool origin) override
+    std::vector<double> getFields(double x, double y, double z) override
     {
-      py::gil_scoped_acquire gil;
-      py::function override = py::get_override(this, "getFields");
-      if (override) {
-        try {
-          return override(x, y, z, origin).cast<std::vector<double>>();
-        } catch (py::error_already_set &e) {
-          if (!e.matches(PyExc_TypeError)) throw;
-          PyErr_Clear();
-          return override(x, y, z).cast<std::vector<double>>();
-        }
-      }
-      return CBDisk::getFields(x, y, z, origin);
+      PYBIND11_OVERRIDE(std::vector<double>, CBDisk, getFields, x, y, z);
     }
 
     void accumulate(double x, double y, double z, double mass, unsigned long int indx) override
@@ -928,21 +865,9 @@ void BasisFactoryClasses(py::module &m)
     // Inherit the constructors
     using Slab::Slab;
 
-    std::vector<double> getFields(double x, double y, double z, bool origin) override
+    std::vector<double> getFields(double x, double y, double z) override
     {
-      py::gil_scoped_acquire gil;
-      py::function overload = py::get_overload(static_cast<const Slab *>(this), "getFields");
-      if (overload) {
-        try {
-          return overload(x, y, z, origin).cast<std::vector<double>>();
-        } catch (py::error_already_set &e) {
-          if (!e.matches(PyExc_TypeError)) throw;
-        }
-
-        return overload(x, y, z).cast<std::vector<double>>();
-      }
-
-      return Slab::getFields(x, y, z, origin);
+      PYBIND11_OVERRIDE(std::vector<double>, Slab, getFields, x, y, z);
     }
 
     void accumulate(double x, double y, double z, double mass, unsigned long int indx) override
@@ -1014,21 +939,9 @@ void BasisFactoryClasses(py::module &m)
     // Inherit the constructors
     using Cube::Cube;
 
-    std::vector<double> getFields(double x, double y, double z, bool origin) override
+    std::vector<double> getFields(double x, double y, double z) override
     {
-      py::function override = py::get_override(this, "getFields");
-      if (override) {
-        try {
-          return override(x, y, z, origin).cast<std::vector<double>>();
-        } catch (py::error_already_set &e) {
-          if (e.matches(PyExc_TypeError)) {
-            e.clear();
-            return override(x, y, z).cast<std::vector<double>>();
-          }
-          throw;
-        }
-      }
-      return Cube::getFields(x, y, z, origin);
+      PYBIND11_OVERRIDE(std::vector<double>, Cube, getFields, x, y, z);
     }
 
     void accumulate(double x, double y, double z, double mass, unsigned long int indx) override
@@ -1613,13 +1526,9 @@ void BasisFactoryClasses(py::module &m)
          potential evaluations are separated into full, axisymmetric and
          non-axisymmetric contributions.
 
-         The origin for field evaluations is the expansion origin by
-         default ('origin=True') Setting 'origin=False' will use the
-         origin defined by the coefficients for field evaluations instead.
-
          You can get the field labels by using the __call__ method of the
          basis object.  This is equivalent to a tuple of the getFields()
-         output with a list of field labels with 'origin=True'.
+         output with a list of field labels.
 
          Parameters
          ----------
@@ -1629,9 +1538,6 @@ void BasisFactoryClasses(py::module &m)
              y-axis position
          z : float
              z-axis position
-         origin : bool
-             If true, the default, origin for field evaluations is (0, 0, 0).
-             If false,  we use the frame defined by the coefficients.
 
          Returns
          -------
@@ -1639,10 +1545,35 @@ void BasisFactoryClasses(py::module &m)
 
          See also
          --------
+         getFieldsOrigin: get fields in coefficient-origin frame
          getFieldsCoefs : get fields for each coefficient set
          __call__       : same as getFields() but provides field labels in a tuple
          )",
-	 py::arg("x"), py::arg("y"), py::arg("z"), py::arg("origin") = true)
+	 py::arg("x"), py::arg("y"), py::arg("z"))
+    .def("getFieldsOrigin", &BasisClasses::BiorthBasis::getFieldsOrigin,
+	 R"(
+         Return the field evaluations for a given Cartesian position in
+         the frame defined by the current coefficients.
+
+         Parameters
+         ----------
+         x : float
+             x-axis position
+         y : float
+             y-axis position
+         z : float
+             z-axis position
+
+         Returns
+         -------
+         fields: numpy.ndarray
+
+         See also
+         --------
+         getFields      : get fields in expansion-origin frame
+         getFieldsCoefs : get fields for each coefficient set
+         )",
+	 py::arg("x"), py::arg("y"), py::arg("z"))
     .def("getAccel", py::overload_cast<double, double, double>(&BasisClasses::BiorthBasis::getAccel),
 	 R"(
          Return the acceleration for a given Cartesian position in the frame defined by the coefficients.
@@ -1741,10 +1672,6 @@ void BasisFactoryClasses(py::module &m)
          for every frame in a coefficient set.  The field evaluations are
          produced by a call to getFields().
 
-         The origin for field evaluations is the expansion origin by
-         default ('origin=True') Setting 'origin=False' will use the
-         origin defined by the coefficients for field evaluations instead.
-
          You get a dictionary of fields keyed by field name and an array
          of evaluation times for convenience.  These times will be the same
          as Times() for the coefficient object.
@@ -1759,9 +1686,6 @@ void BasisFactoryClasses(py::module &m)
              z-axis position
          coefs: CoefClasses::Coefs
              the coefficient set
-         origin : bool
-             If true, the default, origin for field evaluations is (0, 0, 0).
-             If false,  we use the frame defined by the coefficients.
 
          Returns
          -------
@@ -1770,10 +1694,38 @@ void BasisFactoryClasses(py::module &m)
 
          See also
          --------
-         getFields  : get fields for the currently assigned coefficients
-         __call__   : same getFields() but provides field labels in a tuple
+         getFields        : get fields for the currently assigned coefficients
+         getFieldsOrigin  : get fields in coefficient-origin frame
+         __call__         : same getFields() but provides field labels in a tuple
          )",
-	 py::arg("x"), py::arg("y"), py::arg("z"), py::arg("coefs"), py::arg("origin") = true)
+	 py::arg("x"), py::arg("y"), py::arg("z"), py::arg("coefs"))
+    .def("getFieldsCoefsOrigin", &BasisClasses::BiorthBasis::getFieldsCoefsOrigin,
+	 R"(
+         Return the field evaluations for a given Cartesian position
+         for every frame in a coefficient set in the frame defined by
+         each coefficient structure.
+
+         Parameters
+         ----------
+         x : float
+             x-axis position
+         y : float
+             y-axis position
+         z : float
+             z-axis position
+         coefs: CoefClasses::Coefs
+             the coefficient set
+
+         Returns
+         -------
+         tuple of a dictionary of fields of array values, and an
+             array of evaluation times
+
+         See also
+         --------
+         getFieldsCoefs : get fields in expansion-origin frame
+         )",
+	 py::arg("x"), py::arg("y"), py::arg("z"), py::arg("coefs"))
     .def("setFieldType",       &BasisClasses::BiorthBasis::setFieldType,
          R"(
          Set the coordinate system for force evaluations.  The natural 

--- a/pyEXP/BasisWrappers.cc
+++ b/pyEXP/BasisWrappers.cc
@@ -332,7 +332,24 @@ void BasisFactoryClasses(py::module &m)
 
     std::vector<double> getFields(double x, double y, double z, bool origin) override
     {
-      PYBIND11_OVERRIDE(std::vector<double>, Basis, getFields, x, y, z, origin);
+      pybind11::gil_scoped_acquire gil;
+      pybind11::function override_func =
+	pybind11::get_override(static_cast<const Basis*>(this), "getFields");
+      if (override_func) {
+	try {
+	  auto result = override_func(x, y, z, origin);
+	  return result.cast<std::vector<double>>();
+	} catch (pybind11::error_already_set& e) {
+	  if (e.matches(PyExc_TypeError)) {
+	    // Backward-compatible fallback for subclasses with 3-arg signature
+	    PyErr_Clear();
+	    auto result = override_func(x, y, z);
+	    return result.cast<std::vector<double>>();
+	  }
+	  throw;
+	}
+      }
+      return Basis::getFields(x, y, z, origin);
     }
 
     using FCReturn = std::tuple<std::map<std::string, Eigen::VectorXd>,
@@ -341,7 +358,24 @@ void BasisFactoryClasses(py::module &m)
     FCReturn getFieldsCoefs
     (double x, double y, double z, CoefClasses::CoefsPtr coefs, bool origin) override
     {
-      PYBIND11_OVERRIDE(FCReturn, Basis, getFieldsCoefs, x, y, z, coefs, origin);
+      pybind11::gil_scoped_acquire gil;
+      pybind11::function override_func =
+	pybind11::get_override(static_cast<const Basis*>(this), "getFieldsCoefs");
+      if (override_func) {
+	try {
+	  auto result = override_func(x, y, z, coefs, origin);
+	  return result.cast<FCReturn>();
+	} catch (pybind11::error_already_set& e) {
+	  if (e.matches(PyExc_TypeError)) {
+	    // Backward-compatible fallback for subclasses with 4-arg signature
+	    PyErr_Clear();
+	    auto result = override_func(x, y, z, coefs);
+	    return result.cast<FCReturn>();
+	  }
+	  throw;
+	}
+      }
+      return Basis::getFieldsCoefs(x, y, z, coefs, origin);
     }
     
     void accumulate(double x, double y, double z, double mass, unsigned long int indx) override {

--- a/pyEXP/BasisWrappers.cc
+++ b/pyEXP/BasisWrappers.cc
@@ -1661,7 +1661,7 @@ void BasisFactoryClasses(py::module &m)
          coefs: CoefClasses::Coefs
              the coefficient set
          origin : bool
-	     If true, the origin for field evaluations are is (0, 0, 0).
+	     If true, the origin for field evaluations is (0, 0, 0).
              If false, the default, we use the frame defined by the coefficients.
 
          Returns

--- a/pyEXP/BasisWrappers.cc
+++ b/pyEXP/BasisWrappers.cc
@@ -609,7 +609,16 @@ void BasisFactoryClasses(py::module &m)
     using Spherical::Spherical;
 
     std::vector<double> getFields(double x, double y, double z, bool origin) override {
-      PYBIND11_OVERRIDE(std::vector<double>, Spherical, getFields, x, y, z, origin);
+      py::function override = py::get_override(static_cast<const Spherical*>(this), "getFields");
+      if (override) {
+        try {
+          return py::cast<std::vector<double>>(override(x, y, z, origin));
+        } catch (py::error_already_set &e) {
+          if (!e.matches(PyExc_TypeError)) throw;
+        }
+        return py::cast<std::vector<double>>(override(x, y, z));
+      }
+      return Spherical::getFields(x, y, z, origin);
     }
 
     void accumulate(double x, double y, double z, double mass, unsigned long int indx) override {

--- a/pyEXP/BasisWrappers.cc
+++ b/pyEXP/BasisWrappers.cc
@@ -1556,9 +1556,9 @@ void BasisFactoryClasses(py::module &m)
          potential evaluations are separated into full, axisymmetric and
          non-axisymmetric contributions.
 
-         The origin for field evaluations is the frame defined by the
-         coefficients by default.  Setting 'origin=True' will use the
-         origin (0, 0, 0) for field evaluations instead.
+         The origin for field evaluations is the expansion origin by
+         default ('origin=True') Setting 'origin=False' will use the
+         origin defined by the coefficients for field evaluations instead.
 
          You can get the field labels by using the __call__ method of the
          basis object.  This is equivalent to a tuple of the getFields()
@@ -1573,8 +1573,8 @@ void BasisFactoryClasses(py::module &m)
          z : float
              z-axis position
          origin : bool
-	     If true, the origin for field evaluations is (0, 0, 0).
-             If false, the default, we use the frame defined by the coefficients.
+             If true, the default, origin for field evaluations is (0, 0, 0).
+             If false,  we use the frame defined by the coefficients.
 
          Returns
          -------
@@ -1585,7 +1585,7 @@ void BasisFactoryClasses(py::module &m)
          getFieldsCoefs : get fields for each coefficient set
          __call__       : same as getFields() but provides field labels in a tuple
          )",
-	 py::arg("x"), py::arg("y"), py::arg("z"), py::arg("origin") = false)
+	 py::arg("x"), py::arg("y"), py::arg("z"), py::arg("origin") = true)
     .def("getAccel", py::overload_cast<double, double, double>(&BasisClasses::BiorthBasis::getAccel),
 	 R"(
          Return the acceleration for a given Cartesian position in the frame defined by the coefficients.
@@ -1684,9 +1684,9 @@ void BasisFactoryClasses(py::module &m)
          for every frame in a coefficient set.  The field evaluations are
          produced by a call to getFields().
 
-         The origin for field evaluations is the frame defined by the
-         coefficients by default.  Setting 'origin=True' will use the
-         origin (0, 0, 0) for field evaluations instead.
+         The origin for field evaluations is the expansion origin by
+         default ('origin=True') Setting 'origin=False' will use the
+         origin defined by the coefficients for field evaluations instead.
 
          You get a dictionary of fields keyed by field name and an array
          of evaluation times for convenience.  These times will be the same
@@ -1703,8 +1703,8 @@ void BasisFactoryClasses(py::module &m)
          coefs: CoefClasses::Coefs
              the coefficient set
          origin : bool
-	     If true, the origin for field evaluations is (0, 0, 0).
-             If false, the default, we use the frame defined by the coefficients.
+             If true, the default, origin for field evaluations is (0, 0, 0).
+             If false,  we use the frame defined by the coefficients.
 
          Returns
          -------
@@ -1716,7 +1716,7 @@ void BasisFactoryClasses(py::module &m)
          getFields  : get fields for the currently assigned coefficients
          __call__   : same getFields() but provides field labels in a tuple
          )",
-	 py::arg("x"), py::arg("y"), py::arg("z"), py::arg("coefs"), py::arg("origin") = false)
+	 py::arg("x"), py::arg("y"), py::arg("z"), py::arg("coefs"), py::arg("origin") = true)
     .def("setFieldType",       &BasisClasses::BiorthBasis::setFieldType,
          R"(
          Set the coordinate system for force evaluations.  The natural 

--- a/pyEXP/BasisWrappers.cc
+++ b/pyEXP/BasisWrappers.cc
@@ -1522,9 +1522,13 @@ void BasisFactoryClasses(py::module &m)
          potential evaluations are separated into full, axisymmetric and
          non-axisymmetric contributions.
 
-         You can get the fields labels by using the __call__ method of the
+         The origin for field evaluations is the frame defined by the
+         coefficients by default.  Setting 'origin=True' will use the
+         origin (0, 0, 0) for field evaluations instead.
+
+         You can get the field labels by using the __call__ method of the
          basis object.  This is equivalent to a tuple of the getFields()
-         output with a list of field labels.
+         output with a list of field labels with 'origin=True'.
 
          Parameters
          ----------
@@ -1645,6 +1649,10 @@ void BasisFactoryClasses(py::module &m)
          Return the field evaluations for a given Cartesian position
          for every frame in a coefficient set.  The field evaluations are
          produced by a call to getFields().
+
+         The origin for field evaluations is the frame defined by the
+         coefficients by default.  Setting 'origin=True' will use the
+         origin (0, 0, 0) for field evaluations instead.
 
          You get a dictionary of fields keyed by field name and an array
          of evaluation times for convenience.  These times will be the same

--- a/pyEXP/BasisWrappers.cc
+++ b/pyEXP/BasisWrappers.cc
@@ -1535,7 +1535,7 @@ void BasisFactoryClasses(py::module &m)
          z : float
              z-axis position
          origin : bool
-	     If true, the origin for field evaluations are is (0, 0, 0).
+	     If true, the origin for field evaluations is (0, 0, 0).
              If false, the default, we use the frame defined by the coefficients.
 
          Returns

--- a/pyEXP/BasisWrappers.cc
+++ b/pyEXP/BasisWrappers.cc
@@ -330,18 +330,18 @@ void BasisFactoryClasses(py::module &m)
     // Inherit the constructors
     using BasisClasses::Basis::Basis;
 
-    std::vector<double> getFields(double x, double y, double z) override
+    std::vector<double> getFields(double x, double y, double z, bool origin) override
     {
-      PYBIND11_OVERRIDE(std::vector<double>, Basis, getFields, x, y, z);
+      PYBIND11_OVERRIDE(std::vector<double>, Basis, getFields, x, y, z, origin);
     }
 
     using FCReturn = std::tuple<std::map<std::string, Eigen::VectorXd>,
 				Eigen::VectorXd>;
 
     FCReturn getFieldsCoefs
-    (double x, double y, double z, CoefClasses::CoefsPtr coefs) override
+    (double x, double y, double z, CoefClasses::CoefsPtr coefs, bool origin) override
     {
-      PYBIND11_OVERRIDE(FCReturn, Basis, getFieldsCoefs, x, y, z, coefs);
+      PYBIND11_OVERRIDE(FCReturn, Basis, getFieldsCoefs, x, y, z, coefs, origin);
     }
     
     void accumulate(double x, double y, double z, double mass, unsigned long int indx) override {
@@ -434,9 +434,9 @@ void BasisFactoryClasses(py::module &m)
     // Inherit the constructors
     using FieldBasis::FieldBasis;
 
-    std::vector<double> getFields(double x, double y, double z) override
+    std::vector<double> getFields(double x, double y, double z, bool origin) override
     {
-      PYBIND11_OVERRIDE(std::vector<double>, FieldBasis, getFields, x, y, z);
+      PYBIND11_OVERRIDE(std::vector<double>, FieldBasis, getFields, x, y, z, origin);
     }
 
     void accumulate(double m, double x, double y, double z,
@@ -561,8 +561,8 @@ void BasisFactoryClasses(py::module &m)
     // Inherit the constructors
     using Spherical::Spherical;
 
-    std::vector<double> getFields(double x, double y, double z) override {
-      PYBIND11_OVERRIDE(std::vector<double>, Spherical, getFields, x, y, z);
+    std::vector<double> getFields(double x, double y, double z, bool origin) override {
+      PYBIND11_OVERRIDE(std::vector<double>, Spherical, getFields, x, y, z, origin);
     }
 
     void accumulate(double x, double y, double z, double mass, unsigned long int indx) override {
@@ -627,8 +627,8 @@ void BasisFactoryClasses(py::module &m)
     // Inherit the constructors
     using Cylindrical::Cylindrical;
 
-    std::vector<double> getFields(double x, double y, double z) override {
-      PYBIND11_OVERRIDE(std::vector<double>, Cylindrical, getFields, x, y, z);
+    std::vector<double> getFields(double x, double y, double z, bool origin) override {
+      PYBIND11_OVERRIDE(std::vector<double>, Cylindrical, getFields, x, y, z, origin);
     }
 
     void accumulate(double x, double y, double z, double mass, unsigned long int indx) override {
@@ -705,9 +705,9 @@ void BasisFactoryClasses(py::module &m)
     // Inherit the constructors
     using FlatDisk::FlatDisk;
 
-    std::vector<double> getFields(double x, double y, double z) override
+    std::vector<double> getFields(double x, double y, double z, bool origin) override
     {
-      PYBIND11_OVERRIDE(std::vector<double>, FlatDisk, getFields, x, y, z);
+      PYBIND11_OVERRIDE(std::vector<double>, FlatDisk, getFields, x, y, z, origin);
     }
 
     void accumulate(double x, double y, double z, double mass, unsigned long int indx) override
@@ -787,9 +787,9 @@ void BasisFactoryClasses(py::module &m)
     // Inherit the constructors
     using CBDisk::CBDisk;
 
-    std::vector<double> getFields(double x, double y, double z) override
+    std::vector<double> getFields(double x, double y, double z, bool origin) override
     {
-      PYBIND11_OVERRIDE(std::vector<double>, CBDisk, getFields, x, y, z);
+      PYBIND11_OVERRIDE(std::vector<double>, CBDisk, getFields, x, y, z, origin);
     }
 
     void accumulate(double x, double y, double z, double mass, unsigned long int indx) override
@@ -861,9 +861,9 @@ void BasisFactoryClasses(py::module &m)
     // Inherit the constructors
     using Slab::Slab;
 
-    std::vector<double> getFields(double x, double y, double z) override
+    std::vector<double> getFields(double x, double y, double z, bool origin) override
     {
-      PYBIND11_OVERRIDE(std::vector<double>, Slab, getFields, x, y, z);
+      PYBIND11_OVERRIDE(std::vector<double>, Slab, getFields, x, y, z, origin);
     }
 
     void accumulate(double x, double y, double z, double mass, unsigned long int indx) override
@@ -935,9 +935,9 @@ void BasisFactoryClasses(py::module &m)
     // Inherit the constructors
     using Cube::Cube;
 
-    std::vector<double> getFields(double x, double y, double z) override
+    std::vector<double> getFields(double x, double y, double z, bool origin) override
     {
-      PYBIND11_OVERRIDE(std::vector<double>, Cube, getFields, x, y, z);
+      PYBIND11_OVERRIDE(std::vector<double>, Cube, getFields, x, y, z, origin);
     }
 
     void accumulate(double x, double y, double z, double mass, unsigned long int indx) override
@@ -1534,6 +1534,9 @@ void BasisFactoryClasses(py::module &m)
              y-axis position
          z : float
              z-axis position
+         origin : bool
+	     If true, the origin for field evaluations are is (0, 0, 0).
+             If false, the default, we use the frame defined by the coefficients.
 
          Returns
          -------
@@ -1544,10 +1547,10 @@ void BasisFactoryClasses(py::module &m)
          getFieldsCoefs : get fields for each coefficient set
          __call__       : same as getFields() but provides field labels in a tuple
          )",
-	 py::arg("x"), py::arg("y"), py::arg("z"))
+	 py::arg("x"), py::arg("y"), py::arg("z"), py::arg("origin") = false)
     .def("getAccel", py::overload_cast<double, double, double>(&BasisClasses::BiorthBasis::getAccel),
 	 R"(
-         Return the acceleration for a given Cartesian position
+         Return the acceleration for a given Cartesian position in the frame defined by the coeffients.
 
          Parameters
          ----------
@@ -1571,7 +1574,7 @@ void BasisFactoryClasses(py::module &m)
 	 py::arg("x"), py::arg("y"), py::arg("z"))
     .def("getAccel", py::overload_cast<Eigen::Ref<const Eigen::VectorXd>, Eigen::Ref<const Eigen::VectorXd>, Eigen::Ref<const Eigen::VectorXd>>(&BasisClasses::BiorthBasis::getAccel),
 	 R"(
-         Return the acceleration for a given Cartesian position
+         Return the acceleration for a given Cartesian position in the frame defined by the coeffients.
 
          Parameters
          ----------
@@ -1595,7 +1598,7 @@ void BasisFactoryClasses(py::module &m)
 	 py::arg("x"), py::arg("y"), py::arg("z"))
     .def("getAccel", py::overload_cast<Eigen::Ref<const RowMatrixXd>>(&BasisClasses::BiorthBasis::getAccel),
 	 R"(
-         Return the acceleration for an array of Cartesian positions
+         Return the acceleration for an array of Cartesian positions in the frame defined by the coeffients.
 
          Parameters
          ----------
@@ -1615,7 +1618,7 @@ void BasisFactoryClasses(py::module &m)
 	 py::arg("pos"))
     .def("getAccelArray", py::overload_cast<Eigen::Ref<const Eigen::VectorXd>, Eigen::Ref<const Eigen::VectorXd>, Eigen::Ref<const Eigen::VectorXd>>(&BasisClasses::BiorthBasis::getAccel),
 	 R"(
-         Return the acceleration for a given Cartesian position
+         Return the acceleration for a given Cartesian position in the frame defined by the coeffients.
 
          Parameters
          ----------
@@ -1657,6 +1660,9 @@ void BasisFactoryClasses(py::module &m)
              z-axis position
          coefs: CoefClasses::Coefs
              the coefficient set
+         origin : bool
+	     If true, the origin for field evaluations are is (0, 0, 0).
+             If false, the default, we use the frame defined by the coefficients.
 
          Returns
          -------
@@ -1668,7 +1674,7 @@ void BasisFactoryClasses(py::module &m)
          getFields  : get fields for the currently assigned coefficients
          __call__   : same getFields() but provides field labels in a tuple
          )",
-	 py::arg("x"), py::arg("y"), py::arg("z"), py::arg("coefs"))
+	 py::arg("x"), py::arg("y"), py::arg("z"), py::arg("coefs"), py::arg("origin") = false)
     .def("setFieldType",       &BasisClasses::BiorthBasis::setFieldType,
          R"(
          Set the coordinate system for force evaluations.  The natural 

--- a/pyEXP/BasisWrappers.cc
+++ b/pyEXP/BasisWrappers.cc
@@ -930,7 +930,19 @@ void BasisFactoryClasses(py::module &m)
 
     std::vector<double> getFields(double x, double y, double z, bool origin) override
     {
-      PYBIND11_OVERRIDE(std::vector<double>, Slab, getFields, x, y, z, origin);
+      py::gil_scoped_acquire gil;
+      py::function overload = py::get_overload(static_cast<const Slab *>(this), "getFields");
+      if (overload) {
+        try {
+          return overload(x, y, z, origin).cast<std::vector<double>>();
+        } catch (py::error_already_set &e) {
+          if (!e.matches(PyExc_TypeError)) throw;
+        }
+
+        return overload(x, y, z).cast<std::vector<double>>();
+      }
+
+      return Slab::getFields(x, y, z, origin);
     }
 
     void accumulate(double x, double y, double z, double mass, unsigned long int indx) override

--- a/pyEXP/BasisWrappers.cc
+++ b/pyEXP/BasisWrappers.cc
@@ -1550,7 +1550,7 @@ void BasisFactoryClasses(py::module &m)
 	 py::arg("x"), py::arg("y"), py::arg("z"), py::arg("origin") = false)
     .def("getAccel", py::overload_cast<double, double, double>(&BasisClasses::BiorthBasis::getAccel),
 	 R"(
-         Return the acceleration for a given Cartesian position in the frame defined by the coeffients.
+         Return the acceleration for a given Cartesian position in the frame defined by the coefficients.
 
          Parameters
          ----------

--- a/pyEXP/BasisWrappers.cc
+++ b/pyEXP/BasisWrappers.cc
@@ -470,7 +470,20 @@ void BasisFactoryClasses(py::module &m)
 
     std::vector<double> getFields(double x, double y, double z, bool origin) override
     {
-      PYBIND11_OVERRIDE(std::vector<double>, FieldBasis, getFields, x, y, z, origin);
+      py::gil_scoped_acquire gil;
+      py::function override = py::get_override(static_cast<const FieldBasis *>(this), "getFields");
+
+      if (override) {
+        try {
+          return override(x, y, z, origin).cast<std::vector<double>>();
+        } catch (py::error_already_set &e) {
+          if (!e.matches(PyExc_TypeError)) throw;
+          e.clear();
+          return override(x, y, z).cast<std::vector<double>>();
+        }
+      }
+
+      return FieldBasis::getFields(x, y, z, origin);
     }
 
     void accumulate(double m, double x, double y, double z,

--- a/pyEXP/BasisWrappers.cc
+++ b/pyEXP/BasisWrappers.cc
@@ -845,7 +845,18 @@ void BasisFactoryClasses(py::module &m)
 
     std::vector<double> getFields(double x, double y, double z, bool origin) override
     {
-      PYBIND11_OVERRIDE(std::vector<double>, CBDisk, getFields, x, y, z, origin);
+      py::gil_scoped_acquire gil;
+      py::function override = py::get_override(this, "getFields");
+      if (override) {
+        try {
+          return override(x, y, z, origin).cast<std::vector<double>>();
+        } catch (py::error_already_set &e) {
+          if (!e.matches(PyExc_TypeError)) throw;
+          PyErr_Clear();
+          return override(x, y, z).cast<std::vector<double>>();
+        }
+      }
+      return CBDisk::getFields(x, y, z, origin);
     }
 
     void accumulate(double x, double y, double z, double mass, unsigned long int indx) override

--- a/pyEXP/BasisWrappers.cc
+++ b/pyEXP/BasisWrappers.cc
@@ -1016,7 +1016,19 @@ void BasisFactoryClasses(py::module &m)
 
     std::vector<double> getFields(double x, double y, double z, bool origin) override
     {
-      PYBIND11_OVERRIDE(std::vector<double>, Cube, getFields, x, y, z, origin);
+      py::function override = py::get_override(this, "getFields");
+      if (override) {
+        try {
+          return override(x, y, z, origin).cast<std::vector<double>>();
+        } catch (py::error_already_set &e) {
+          if (e.matches(PyExc_TypeError)) {
+            e.clear();
+            return override(x, y, z).cast<std::vector<double>>();
+          }
+          throw;
+        }
+      }
+      return Cube::getFields(x, y, z, origin);
     }
 
     void accumulate(double x, double y, double z, double mass, unsigned long int indx) override


### PR DESCRIPTION
# Feature update

The `getAccel` and `getFields` API now evaluate in the coordinate origin specified by the coefficients.  Previous behavior required the user to supply the desired center.  This is needed for Gala, but users now of the option of choosing the expansion center as origin (default) or the coefficient-specified center in `getFields()`. 

This fixes a bug in the sense that the original interface used by Gala was not implemented as intended.

# Details

- `getAccel()` has the same call signature in the API but now uses the center metadata fields in the registered coefficient instance so that the coordinates are _simulation_ coordinates.
- `getFields()` retains the original behavior.  If one needs the same centering behavior as `getAccel()`,  I have added a new member function that uses the coordinate origin: `getFieldsOrigin()`.

# Warnings

While not formally an API-breaking change, any workflows that used `getAccel()` and assumed expansion origin will find that they now are using the original simulation origin.  For this reason, I am basing this PR on [devel](https://github.com/EXP-code/EXP/tree/devel).  We might consider rebasing this on [main](https://github.com/EXP-code/EXP/tree/main).

The Gala calls to `getFields()` in `exp_fields.cc` will need to be updated to `getFieldsOrigin()`.

# Additional minor fix

Updated the public header target to include CUDA-specific files.

# ToDo

- [x] Verify compilation
- [x] Check that this fixes the issue identified by @hfoote 
- [x] Run other workflow regression tests