### PR TITLE
Missing global key

### DIFF
--- a/src/global_key_set.H
+++ b/src/global_key_set.H
@@ -8,7 +8,7 @@ global_valid_keys = {
   "dbthresh",
   "time",
   "dtime",
-  "maxMindt"
+  "maxMindt",
   "PFbufsz",
   "NICE",
   "VERBOSE",

--- a/src/global_key_set.H
+++ b/src/global_key_set.H
@@ -8,6 +8,7 @@ global_valid_keys = {
   "dbthresh",
   "time",
   "dtime",
+  "maxMindt"
   "PFbufsz",
   "NICE",
   "VERBOSE",


### PR DESCRIPTION
## Issue

Wanted to use adjust `max_mindt` for testing and found that it was not in the global key list.

## Fix

Added the key.   One-liner.