### PR TITLE
Add additional attributes to cylindrical cache file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.25) # Needed for CUDA, MPI, and CTest features
 
 project(
   EXP
-  VERSION "7.11.0"
+  VERSION "7.11.1"
   HOMEPAGE_URL https://github.com/EXP-code/EXP
   LANGUAGES C CXX Fortran)
 

--- a/doc/exp.cfg
+++ b/doc/exp.cfg
@@ -48,7 +48,7 @@ PROJECT_NAME           = EXP
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 7.11.0
+PROJECT_NUMBER         = 7.11.1
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/doc/exp.cfg.breathe
+++ b/doc/exp.cfg.breathe
@@ -48,7 +48,7 @@ PROJECT_NAME           = EXP
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 7.11.0
+PROJECT_NUMBER         = 7.11.1
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/exputil/EmpCylSL.cc
+++ b/exputil/EmpCylSL.cc
@@ -2412,6 +2412,11 @@ void EmpCylSL::generate_eof(int numr, int nump, int numt,
     orthoTest(ortho->orthoCheck(std::max<int>(NMAX*50, 200)), "EmpCylSL[SLGridSph]", "l");
   }
 
+  // Save quadrature parameters for provenance
+  //
+  eof_vars.numr = numr;
+  eof_vars.nump = nump;
+  eof_vars.numt = numt;
 
   // Initialize fixed variables and storage
   //
@@ -7413,29 +7418,51 @@ void EmpCylSL::WriteH5Cache()
     std::string forceID("Cylinder"), geometry("cylinder");
     std::string model = EmpModelLabs[mtype];
 
-    file.createAttribute<std::string>("geometry", HighFive::DataSpace::From(geometry)).write(geometry);
-    file.createAttribute<std::string>("forceID",  HighFive::DataSpace::From(forceID)).write(forceID);
-    file.createAttribute<std::string>("Version",  HighFive::DataSpace::From(Version)).write(Version);
+    file.createAttribute<std::string>("geometry",  HighFive::DataSpace::From(geometry)).write(geometry);
+    file.createAttribute<std::string>("forceID",   HighFive::DataSpace::From(forceID)). write(forceID);
+    file.createAttribute<std::string>("Version",   HighFive::DataSpace::From(Version)). write(Version);
       
-    // Write the specific parameters
+    // Write the grid specific parameters
     //
-    file.createAttribute<std::string>("model",   HighFive::DataSpace::From(model)).   write(model);
-    file.createAttribute<int>        ("mmax",    HighFive::DataSpace::From(MMAX)).    write(MMAX);
-    file.createAttribute<int>        ("numx",    HighFive::DataSpace::From(NUMX)).    write(NUMX);
-    file.createAttribute<int>        ("numy",    HighFive::DataSpace::From(NUMY)).    write(NUMY);
-    file.createAttribute<int>        ("nmax",    HighFive::DataSpace::From(NORDER)).  write(NORDER);
-    file.createAttribute<int>        ("lmaxfid", HighFive::DataSpace::From(LMAX)).    write(LMAX);
-    file.createAttribute<int>        ("nmaxfid", HighFive::DataSpace::From(NMAX)).    write(NMAX);
-    file.createAttribute<int>        ("neven",   HighFive::DataSpace::From(Neven)).   write(Neven);
-    file.createAttribute<int>        ("nodd",    HighFive::DataSpace::From(Nodd)).    write(Nodd);
-    file.createAttribute<int>        ("cmapr",   HighFive::DataSpace::From(CMAPR)).   write(CMAPR);
-    file.createAttribute<int>        ("cmapz",   HighFive::DataSpace::From(CMAPZ)).   write(CMAPZ);
-    file.createAttribute<double>     ("rmin",    HighFive::DataSpace::From(RMIN)).    write(RMIN);
-    file.createAttribute<double>     ("rmax",    HighFive::DataSpace::From(RMAX)).    write(RMAX);
-    file.createAttribute<double>     ("ascl",    HighFive::DataSpace::From(ASCALE)).  write(ASCALE);
-    file.createAttribute<double>     ("hscl",    HighFive::DataSpace::From(HSCALE)).  write(HSCALE);
-    file.createAttribute<double>     ("cmass",   HighFive::DataSpace::From(cylmass)). write(cylmass);
+    file.createAttribute<std::string>("model",     HighFive::DataSpace::From(model)).   write(model);
+    file.createAttribute<int>        ("mmax",      HighFive::DataSpace::From(MMAX)).    write(MMAX);
+    file.createAttribute<int>        ("numx",      HighFive::DataSpace::From(NUMX)).    write(NUMX);
+    file.createAttribute<int>        ("numy",      HighFive::DataSpace::From(NUMY)).    write(NUMY);
+    file.createAttribute<int>        ("nmax",      HighFive::DataSpace::From(NORDER)).  write(NORDER);
+    file.createAttribute<int>        ("lmaxfid",   HighFive::DataSpace::From(LMAX)).    write(LMAX);
+    file.createAttribute<int>        ("nmaxfid",   HighFive::DataSpace::From(NMAX)).    write(NMAX);
+    file.createAttribute<int>        ("neven",     HighFive::DataSpace::From(Neven)).   write(Neven);
+    file.createAttribute<int>        ("nodd",      HighFive::DataSpace::From(Nodd)).    write(Nodd);
+    file.createAttribute<int>        ("cmapr",     HighFive::DataSpace::From(CMAPR)).   write(CMAPR);
+    file.createAttribute<int>        ("cmapz",     HighFive::DataSpace::From(CMAPZ)).   write(CMAPZ);
+    file.createAttribute<double>     ("rmin",      HighFive::DataSpace::From(RMIN)).    write(RMIN);
+    file.createAttribute<double>     ("rmax",      HighFive::DataSpace::From(RMAX)).    write(RMAX);
+    file.createAttribute<double>     ("ascl",      HighFive::DataSpace::From(ASCALE)).  write(ASCALE);
+    file.createAttribute<double>     ("hscl",      HighFive::DataSpace::From(HSCALE)).  write(HSCALE);
+    file.createAttribute<double>     ("cmass",     HighFive::DataSpace::From(cylmass)). write(cylmass);
       
+    // Additional unchecked variables
+    //
+    file.createAttribute<bool>       ("PCAVAR",    HighFive::DataSpace::From(PCAVAR)).  write(PCAVAR);
+    file.createAttribute<bool>       ("PCAVTK",    HighFive::DataSpace::From(PCAVTK)).  write(PCAVTK);
+    file.createAttribute<bool>       ("PCAEOF",    HighFive::DataSpace::From(PCAEOF)).  write(PCAEOF);
+    file.createAttribute<int>        ("numr",      HighFive::DataSpace::From(NUMR)).    write(NUMR);
+    file.createAttribute<double>     ("hexp",      HighFive::DataSpace::From(HEXP)).    write(HEXP);
+    file.createAttribute<double>     ("hfac",      HighFive::DataSpace::From(HFAC)).    write(HFAC);
+    file.createAttribute<double>     ("ppow",      HighFive::DataSpace::From(PPOW)).    write(PPOW);
+
+    // Options
+    //
+    file.createAttribute<bool>       ("logarithmic",    HighFive::DataSpace::From(logarithmic)).   write(logarithmic);
+    file.createAttribute<bool>       ("enforce_limits", HighFive::DataSpace::From(enforce_limits)).write(enforce_limits);
+
+    // EOF quadrature parameters
+    //
+    file.createAttribute<int>        ("eof_numr",  HighFive::DataSpace::From(eof_vars.numr)).write(eof_vars.numr);
+    file.createAttribute<int>        ("eof_nump",  HighFive::DataSpace::From(eof_vars.nump)).write(eof_vars.nump);
+    file.createAttribute<int>        ("eof_numt",  HighFive::DataSpace::From(eof_vars.numt)).write(eof_vars.numt);
+
+
     // Cosine functions
 
     auto cosine = file.createGroup("Cosine");

--- a/include/EmpCylSL.H
+++ b/include/EmpCylSL.H
@@ -79,9 +79,9 @@ protected:
   double pfac, dfac, ffac;
 
   // For provenance
-  struct eof_variables {
-    int numr, nump, numt;
-  } eof_vars;
+struct eof_variables {
+  int numr{-1}, nump{-1}, numt{-1};
+} eof_vars;
 
   std::vector<Eigen::MatrixXd> facC, facS;
 

--- a/include/EmpCylSL.H
+++ b/include/EmpCylSL.H
@@ -78,6 +78,11 @@ protected:
   double HSCALE;
   double pfac, dfac, ffac;
 
+  // For provenance
+  struct eof_variables {
+    int numr, nump, numt;
+  } eof_vars;
+
   std::vector<Eigen::MatrixXd> facC, facS;
 
   int rank2, rank3;


### PR DESCRIPTION
## What and why

Add all parameters that uniquely identify the state on construction for future reproduction and provenance.

Added parameters include:

- PCAVAR: enable variance computation
- PCAVTK: emit VTK files for diagnostic.  Not used in production.
- PCAEOF: enable variance with weights for EOF mode.  Not currently used for production.
- numr: the grid size of the spherical model used for disk basis construction
- hexp: exponent for Hall smoothing
- hfac: sets the finite difference scale when using logarithmic spacing.  This has been tuned somewhat so I don't recommending changing this but you can...
- ppow: exponent for the power-law disk target model 'Power'
- logarithmic: use logarithmic spacing for the spherical model grid used to construct the basis
- enforce_limits: if true, prevent extrapolating off the basis grid
    file.createAttribute<bool>       ("enforce_limits", HighFive::DataSpace::From(enforce_limits)).write(enforce_limits);
- eof_numr: number of radial quadrature points for projecting the basis functions against the disk target
- eof_nump: number of azimuthal quadrature points for the projection
- eof_numt: number of colatitude quadrature points

## Notes

These changes are non invasive and can not break older versions of EXP.

## Tests

- [x] Compiles
- [x] Cache created and examined
- [x] Cache successfully reread by `Basis`
- [x] Check to make sure all necessary parameters are stored as attributes