### PR TITLE
Finish pybind11 dependence removal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,10 @@ option(BUILD_DOCS "Build documentation" OFF)
 option(DISABLE_PYTHON "Disable the Python development environment" OFF)
 if(DISABLE_PYTHON)
   message(STATUS "Python development environment is disabled.  pyEXP will not be built.")
-  set(ENABLE_PYEXP OFF)
+  if(ENABLE_PYEXP_ONLY)
+    message(FATAL_ERROR "DISABLE_PYTHON=ON is incompatible with ENABLE_PYEXP_ONLY=ON.")
+  endif()
+  set(ENABLE_PYEXP OFF CACHE BOOL "Enable the Python bindings" FORCE)
 endif()
 
 # Metaflag for minimal build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,10 @@ option(ENABLE_MINIMAL "Compile EXP support libraries only" OFF)
 option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
 option(BUILD_DOCS "Build documentation" OFF)
 option(DISABLE_PYTHON "Disable the Python development environment" OFF)
+if(DISABLE_PYTHON)
+  message(STATUS "Python development environment is disabled.  pyEXP will not be built.")
+  set(ENABLE_PYEXP OFF)
+endif()
 
 # Metaflag for minimal build
 
@@ -259,14 +263,18 @@ execute_process(
 )
 
 include_directories(${PROJECT_SOURCE_DIR}/extern/yaml-cpp/include)
-include_directories(${PROJECT_SOURCE_DIR}/extern/pybind11/include)
+if (NOT DISABLE_PYTHON)
+  include_directories(${PROJECT_SOURCE_DIR}/extern/pybind11/include)
+endif()
 include_directories(${PROJECT_SOURCE_DIR}/extern/QuickDigest5/include)
 
 # Report to the user
 message("Configuring build for ${GIT_BRANCH}/${GIT_COMMIT} at ${COMPILE_TIME}")
 
 add_subdirectory(extern/yaml-cpp)
-add_subdirectory(extern/pybind11)
+if (NOT DISABLE_PYTHON)
+  add_subdirectory(extern/pybind11)
+endif()
 
 # Set options for the HighFive git submodule in extern
 set(HIGHFIVE_EXAMPLES OFF CACHE BOOL "Do not build the examples")

--- a/exputil/CMakeLists.txt
+++ b/exputil/CMakeLists.txt
@@ -62,7 +62,11 @@ set(common_INCLUDE_DIRS $<INSTALL_INTERFACE:include>
 
 set(common_LINKLIB ${DEP_LIB} OpenMP::OpenMP_CXX MPI::MPI_CXX yaml-cpp
   ${VTK_LIBRARIES} ${HDF5_CXX_LIBRARIES} ${HDF5_LIBRARIES}
-  ${HDF5_HL_LIBRARIES} ${FFTW_DOUBLE_LIB} pybind11::embed)
+  ${HDF5_HL_LIBRARIES} ${FFTW_DOUBLE_LIB})
+if(NOT DISABLE_PYTHON)
+    list(APPEND common_LINKLIB pybind11::embed)
+endif()
+
 
 if(ENABLE_CUDA)
   list(APPEND common_LINKLIB CUDA::toolkit CUDA::cudart)

--- a/exputil/realize_model.cc
+++ b/exputil/realize_model.cc
@@ -33,6 +33,7 @@
 #include <random>
 #include <memory>
 #include <cmath>
+#include <cassert>
 
 #include "localmpi.H"
 #include "massmodel.H"

--- a/utils/Test/CMakeLists.txt
+++ b/utils/Test/CMakeLists.txt
@@ -1,6 +1,10 @@
 
 set(bin_PROGRAMS testBarrier expyaml orthoTest testDeproj
-		 testEmpDeproj testEmp testED testmd5)
+		 testEmpDeproj testED testmd5)
+
+if(NOT DISABLE_PYTHON)
+  list(APPEND bin_PROGRAMS testEmp)
+endif()
 
 set(common_LINKLIB OpenMP::OpenMP_CXX MPI::MPI_CXX expui exputil
   yaml-cpp ${VTK_LIBRARIES})
@@ -37,7 +41,9 @@ add_executable(orthoTest      orthoTest.cc Biorth2Ortho.cc)
 add_executable(testDeproj     testDeproject.cc CubicSpline.cc Deprojector.cc)
 add_executable(testEmpDeproj  testEmpDeproj.cc CubicSpline.cc
 			      Deprojector.cc EmpDeproj.cc)
-add_executable(testEmp        testEmp.cc EmpDeproj.cc)
+if(NOT DISABLE_PYTHON)
+  add_executable(testEmp        testEmp.cc EmpDeproj.cc)
+endif()
 add_executable(testmd5        testmd5.cc)
 add_executable(testED         testED.cc EmpDeproj.cc)
 
@@ -49,6 +55,8 @@ foreach(program ${bin_PROGRAMS})
 endforeach()
 
 # For Python interpreter...
-target_link_libraries(testEmp ${common_LINKLIB} pybind11::embed)
+if(NOT DISABLE_PYTHON)
+  target_link_libraries(testEmp ${common_LINKLIB} pybind11::embed)
+endif()
 
 install(TARGETS expyaml DESTINATION bin)


### PR DESCRIPTION
This pull request improves support for disabling the Python development environment by making the build system respect the `DISABLE_PYTHON` option throughout the CMake configuration. The changes ensure that Python-related dependencies and targets are only included when Python support is enabled, resulting in a cleaner and more robust build process when Python is not required.

**Build system improvements for Python support:**

* Added logic in `CMakeLists.txt` to set `ENABLE_PYEXP` to `OFF` and print a status message when `DISABLE_PYTHON` is enabled, preventing the build of Python-related components.
* Conditionalized inclusion of `pybind11` headers and subdirectory in the main `CMakeLists.txt` and only add them if Python is not disabled.
* Updated `exputil/CMakeLists.txt` to only link against `pybind11::embed` if Python support is enabled, avoiding unnecessary dependencies.

**Test utilities adjustments:**

* Modified `utils/Test/CMakeLists.txt` to only add and link the `testEmp` executable (and its dependencies) if Python is enabled, ensuring test targets are consistent with the build configuration. 

**Minor code improvement:**

* Added a missing `#include <cassert>` in `exputil/realize_model.cc` for improved code safety and correctness.